### PR TITLE
Fix redundant check in popup positioning

### DIFF
--- a/index.html
+++ b/index.html
@@ -1367,8 +1367,6 @@
 
                 if (newLeft > maxLeft) newLeft = maxLeft;
                 if (newLeft < minLeft) newLeft = minLeft; // Ensure it doesn't go too far left
-                if (newLeft < minLeft) newLeft = minLeft;
-
             } else {
                 console.log("[DEBUG positionPopup] Context: Main Page");
                 // Position relative to the document/viewport
@@ -1384,9 +1382,6 @@
 
                 if (newLeft > maxLeft) newLeft = maxLeft;
                 if (newLeft < minLeft) newLeft = minLeft; // Ensure it doesn't go too far left
-                if (newLeft < minLeft) newLeft = minLeft;
-            }
-
             // newTop and newLeft are target absolute positions in their respective coordinate systems
             // (document-relative for main page, overlay-content-relative for overlay)
             // We need to convert these to style.top/left relative to the popup's offsetParent.


### PR DESCRIPTION
## Summary
- remove duplicate `newLeft < minLeft` checks in `positionPopup`

## Testing
- `npm test` *(fails: missing `package.json`)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f9b0b6c288323bf6e15635de6880c