### PR TITLE
Add Jest test for signout localStorage behavior

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "jaxs",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "jest"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "devDependencies": {
+    "jest": "^29.7.0"
+  },
+  "jest": {
+    "testEnvironment": "jsdom"
+  }
+}

--- a/tests/signout.test.js
+++ b/tests/signout.test.js
@@ -1,0 +1,29 @@
+function handleSignOut(userId) {
+  // This mimics the onAuthStateChanged handler when the user logs out
+  localStorage.removeItem(`mediaFinderLastSelectedWatchlist_${userId}`);
+}
+
+describe('sign out flow', () => {
+  const USER_ID = 'abc123';
+
+  // Provide a simple localStorage mock
+  let store;
+  beforeEach(() => {
+    store = {};
+    Object.defineProperty(global, 'localStorage', {
+      value: {
+        getItem: (key) => store[key] || null,
+        setItem: (key, value) => { store[key] = String(value); },
+        removeItem: (key) => { delete store[key]; },
+        clear: () => { store = {}; }
+      },
+      configurable: true
+    });
+  });
+
+  test('removes last selected watchlist key on sign out', () => {
+    localStorage.setItem(`mediaFinderLastSelectedWatchlist_${USER_ID}`, 'test');
+    handleSignOut(USER_ID);
+    expect(localStorage.getItem(`mediaFinderLastSelectedWatchlist_${USER_ID}`)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- add a minimal Node package configuration with Jest
- create a simple test for sign-out localStorage cleanup

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fad27e2708323811fb998d4938845