### PR TITLE
Add Jest setup with sign-out localStorage test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/package.json
+++ b/package.json
@@ -6,11 +6,10 @@
     "test": "jest"
   },
   "devDependencies": {
-    "jest": "^29.7.0",
-    "jsdom": "^24.0.0"
+    "jest": "^29.7.0"
   },
   "jest": {
-    "testEnvironment": "jsdom",
+    "testEnvironment": "node",
     "testMatch": ["**/tests/**/*.test.js"]
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "jaxs",
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "test": "jest"
+  },
+  "devDependencies": {
+    "jest": "^29.7.0",
+    "jsdom": "^24.0.0"
+  },
+  "jest": {
+    "testEnvironment": "jsdom",
+    "testMatch": ["**/tests/**/*.test.js"]
+  }
+}

--- a/tests/signout.test.js
+++ b/tests/signout.test.js
@@ -1,0 +1,22 @@
+import { JSDOM } from 'jsdom';
+
+function triggerSignOut(userId) {
+  // Simulates the sign-out cleanup performed in index.html
+  localStorage.removeItem(`mediaFinderLastSelectedWatchlist_${userId}`);
+}
+
+describe('Sign-out cleanup', () => {
+  test('removes mediaFinderLastSelectedWatchlist_<USERID> from localStorage', () => {
+    const dom = new JSDOM('', { url: 'http://localhost/' });
+    global.window = dom.window;
+    global.document = dom.window.document;
+    global.localStorage = dom.window.localStorage;
+
+    const userId = 'user123';
+    localStorage.setItem(`mediaFinderLastSelectedWatchlist_${userId}`, 'dummy');
+    const spy = jest.spyOn(window.localStorage.__proto__, 'removeItem');
+    triggerSignOut(userId);
+    expect(spy).toHaveBeenCalledWith(`mediaFinderLastSelectedWatchlist_${userId}`);
+    expect(localStorage.getItem(`mediaFinderLastSelectedWatchlist_${userId}`)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- set up a minimal Jest configuration
- ignore `node_modules`
- test sign-out behaviour to ensure `mediaFinderLastSelectedWatchlist_<USERID>` is cleared

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fbe5f28948323b87d6185df2c812f