### PR TITLE
Use overlay for more item selections

### DIFF
--- a/handlers.js
+++ b/handlers.js
@@ -14,7 +14,7 @@ import {
 
 // DOM Elements
 let detailOverlay, detailOverlayContent, searchView, latestView, popularView, watchlistView,
-    tabLatest, tabPopular, 
+    tabLatest, tabPopular, tabSearch, tabWatchlist,
     latestContentDisplay, popularContentDisplay,
     itemDetailTitle, overlayDetailTitle, watchlistItemDetailTitle,
     itemDetailContainer, overlayDetailContainer, watchlistItemDetailContainer,
@@ -34,6 +34,8 @@ export function initHandlerRefs(elements) {
     watchlistView = elements.watchlistView;
     tabLatest = elements.tabLatest;
     tabPopular = elements.tabPopular;
+    tabSearch = elements.tabSearch;
+    tabWatchlist = elements.tabWatchlist;
     latestContentDisplay = elements.latestContentDisplay;
     popularContentDisplay = elements.popularContentDisplay;
     itemDetailTitle = elements.itemDetailTitle;
@@ -76,14 +78,19 @@ export async function handleItemSelect(itemId, itemTitle, itemType, calledFromGe
         currentPlayerEl = overlayVidsrcPlayerSection;
         currentBackButtonContainerEl = overlayBackButtonContainer;
 
-        const activeMainTabForState = latestView && !latestView.classList.contains('hidden-view') ? tabLatest : tabPopular;
-        if (activeMainTabForState) {
-            updatePreviousStateForBackButton({ originTabId: activeMainTabForState.id });
-            if (previousStateForBackButton.originTabId === 'tabLatest' && latestContentDisplay) {
-                updateScrollPosition('latest', latestContentDisplay.scrollTop);
-            } else if (previousStateForBackButton.originTabId === 'tabPopular' && popularContentDisplay) {
-                updateScrollPosition('popular', popularContentDisplay.scrollTop);
-            }
+        const activeOriginTab =
+            (searchView && !searchView.classList.contains('hidden-view')) ? tabSearch :
+            (watchlistView && !watchlistView.classList.contains('hidden-view')) ? tabWatchlist :
+            (latestView && !latestView.classList.contains('hidden-view')) ? tabLatest :
+            tabPopular;
+
+        updatePreviousStateForBackButton({ originTabId: activeOriginTab.id });
+
+        if (activeOriginTab.id === 'tabLatest' && latestContentDisplay) {
+            updateScrollPosition('latest', latestContentDisplay.scrollTop);
+            showPositionSavedIndicator();
+        } else if (activeOriginTab.id === 'tabPopular' && popularContentDisplay) {
+            updateScrollPosition('popular', popularContentDisplay.scrollTop);
             showPositionSavedIndicator();
         }
         if (detailOverlay) detailOverlay.classList.remove('hidden');
@@ -124,7 +131,15 @@ export async function handleItemSelect(itemId, itemTitle, itemType, calledFromGe
         currentBackButtonContainerEl.innerHTML = '';
         let backButtonContext;
         if (currentTargetViewContext === 'overlay' && previousStateForBackButton) {
-            backButtonContext = previousStateForBackButton.originTabId === 'tabLatest' ? 'latestList' : 'popularList';
+            if (previousStateForBackButton.originTabId === 'tabLatest') {
+                backButtonContext = 'latestList';
+            } else if (previousStateForBackButton.originTabId === 'tabPopular') {
+                backButtonContext = 'popularList';
+            } else if (previousStateForBackButton.originTabId === 'tabWatchlist') {
+                backButtonContext = 'watchlistItemsList';
+            } else {
+                backButtonContext = 'searchList';
+            }
         } else if (currentTargetViewContext === 'watchlist') {
             backButtonContext = 'watchlistItemsList';
         } else if (currentTargetViewContext === 'item') {

--- a/ui.js
+++ b/ui.js
@@ -178,9 +178,19 @@ export function createBackButton(originContext) {
                 popularContentDisplay.scrollTop = scrollPositions.popular;
             }
         } else if (originContext === 'watchlistItemsList') {
-            clearItemDetailPanel('watchlist'); 
+            if (detailOverlay && !detailOverlay.classList.contains('hidden')) {
+                detailOverlay.classList.add('hidden');
+                clearItemDetailPanel('overlay');
+            } else {
+                clearItemDetailPanel('watchlist');
+            }
         } else if (originContext === 'searchList') {
-            clearItemDetailPanel('item'); // This will ONLY clear the item detail, search results are not touched here.
+            if (detailOverlay && !detailOverlay.classList.contains('hidden')) {
+                detailOverlay.classList.add('hidden');
+                clearItemDetailPanel('overlay');
+            } else {
+                clearItemDetailPanel('item'); // This will ONLY clear the item detail, search results are not touched here.
+            }
         }
         updatePreviousStateForBackButton(null);
     };
@@ -217,7 +227,8 @@ export function displayResults(items, itemType, resContainer) {
             <p class="text-[10px] text-gray-400">${year}</p>
             ${item.vote_average && item.vote_average > 0 ? `<p class="text-[10px] text-yellow-400">★ ${item.vote_average.toFixed(1)}</p>` : ''}
         `;
-        card.addEventListener('click', () => handleItemSelect(String(item.id), title, itemType));
+        // Open details in the overlay when selecting from search results
+        card.addEventListener('click', () => handleItemSelect(String(item.id), title, itemType, true));
         flexContainer.appendChild(card);
         appendSeenCheckmark(card, String(item.id)); 
     });

--- a/watchlist.js
+++ b/watchlist.js
@@ -272,7 +272,8 @@ export function createWatchlistItemCard(item) {
     `;
     const removeBtn = card.querySelector('.remove-watchlist-btn');
     removeBtn.addEventListener('click', (e) => { e.stopPropagation(); removeItemFromSpecificFirestoreWatchlist(currentSelectedWatchlistName, item.tmdb_id); });
-    card.addEventListener('click', () => { handleItemSelect(item.tmdb_id, item.title, item.item_type, false, true); });
+    // Use overlay for watchlist item details
+    card.addEventListener('click', () => { handleItemSelect(item.tmdb_id, item.title, item.item_type, true); });
     appendSeenCheckmark(card, item.tmdb_id); // From seenList.js
     return card;
 }


### PR DESCRIPTION
## Summary
- show overlay detail view when selecting search results
- open watchlist item selections in the overlay
- track the active tab in `handleItemSelect`
- update back button logic for watchlist and search overlays

## Testing
- `npm test` *(fails: jest not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6840beb7e54c8323b39258a1a0e775d1