### PR TITLE
Add overlay layout to search and watchlist tabs

### DIFF
--- a/handlers.js
+++ b/handlers.js
@@ -14,7 +14,7 @@ import {
 
 // DOM Elements
 let detailOverlay, detailOverlayContent, searchView, latestView, popularView, watchlistView,
-    tabLatest, tabPopular, 
+    tabLatest, tabPopular, tabSearch, tabWatchlist,
     latestContentDisplay, popularContentDisplay,
     itemDetailTitle, overlayDetailTitle, watchlistItemDetailTitle,
     itemDetailContainer, overlayDetailContainer, watchlistItemDetailContainer,
@@ -34,6 +34,8 @@ export function initHandlerRefs(elements) {
     watchlistView = elements.watchlistView;
     tabLatest = elements.tabLatest;
     tabPopular = elements.tabPopular;
+    tabSearch = elements.tabSearch;
+    tabWatchlist = elements.tabWatchlist;
     latestContentDisplay = elements.latestContentDisplay;
     popularContentDisplay = elements.popularContentDisplay;
     itemDetailTitle = elements.itemDetailTitle;
@@ -76,14 +78,19 @@ export async function handleItemSelect(itemId, itemTitle, itemType, calledFromGe
         currentPlayerEl = overlayVidsrcPlayerSection;
         currentBackButtonContainerEl = overlayBackButtonContainer;
 
-        const activeMainTabForState = latestView && !latestView.classList.contains('hidden-view') ? tabLatest : tabPopular;
-        if (activeMainTabForState) {
-            updatePreviousStateForBackButton({ originTabId: activeMainTabForState.id });
-            if (previousStateForBackButton.originTabId === 'tabLatest' && latestContentDisplay) {
-                updateScrollPosition('latest', latestContentDisplay.scrollTop);
-            } else if (previousStateForBackButton.originTabId === 'tabPopular' && popularContentDisplay) {
-                updateScrollPosition('popular', popularContentDisplay.scrollTop);
-            }
+        const activeOriginTab =
+            (searchView && !searchView.classList.contains('hidden-view')) ? tabSearch :
+            (watchlistView && !watchlistView.classList.contains('hidden-view')) ? tabWatchlist :
+            (latestView && !latestView.classList.contains('hidden-view')) ? tabLatest :
+            tabPopular;
+
+        updatePreviousStateForBackButton({ originTabId: activeOriginTab.id });
+
+        if (activeOriginTab.id === 'tabLatest' && latestContentDisplay) {
+            updateScrollPosition('latest', latestContentDisplay.scrollTop);
+            showPositionSavedIndicator();
+        } else if (activeOriginTab.id === 'tabPopular' && popularContentDisplay) {
+            updateScrollPosition('popular', popularContentDisplay.scrollTop);
             showPositionSavedIndicator();
         }
         if (detailOverlay) detailOverlay.classList.remove('hidden');
@@ -124,7 +131,15 @@ export async function handleItemSelect(itemId, itemTitle, itemType, calledFromGe
         currentBackButtonContainerEl.innerHTML = '';
         let backButtonContext;
         if (currentTargetViewContext === 'overlay' && previousStateForBackButton) {
-            backButtonContext = previousStateForBackButton.originTabId === 'tabLatest' ? 'latestList' : 'popularList';
+            if (previousStateForBackButton.originTabId === 'tabLatest') {
+                backButtonContext = 'latestList';
+            } else if (previousStateForBackButton.originTabId === 'tabPopular') {
+                backButtonContext = 'popularList';
+            } else if (previousStateForBackButton.originTabId === 'tabWatchlist') {
+                backButtonContext = 'watchlistItemsList';
+            } else {
+                backButtonContext = 'searchList';
+            }
         } else if (currentTargetViewContext === 'watchlist') {
             backButtonContext = 'watchlistItemsList';
         } else if (currentTargetViewContext === 'item') {

--- a/index.html
+++ b/index.html
@@ -373,20 +373,8 @@
                     <button id="searchButton" class="bg-sky-500 hover:bg-sky-600 text-white font-semibold py-3 px-6 rounded-lg transition duration-200 shadow-md hover:shadow-lg">Search</button>
                 </div>
             </div>
-            <div class="grid grid-cols-1 md:grid-cols-3 gap-8">
-                <div id="resultsSection" class="md:col-span-1 bg-gray-800 p-6 rounded-lg shadow-xl">
-                    <h2 class="section-title">Search Results</h2>
-                    <div id="resultsContainer" class="space-y-3 max-h-[calc(100vh-450px)] md:max-h-[70vh] overflow-y-auto pr-2"><p class="text-gray-500 italic">Search for media.</p></div>
-                </div>
-                <div id="itemDetailSection" class="md:col-span-2 bg-gray-800 p-6 rounded-lg shadow-xl min-h-[400px]">
-                    <div id="itemBackButtonContainer" class="mb-2"></div>
-                    <h2 id="itemDetailTitle" class="section-title">Details & Player</h2>
-                    <div id="itemDetailContainer"><p class="text-gray-500 italic">Select an item.</p></div>
-                    <div id="itemVidsrcPlayerSection" class="mt-4"></div>
-                    <div id="itemSeasonsEpisodesSection" class="mt-4"></div>
-                    <div id="itemRelatedItemsSection" class="mt-6"></div>
-                    <div id="itemCollectionItemsSection" class="mt-6"></div>
-                </div>
+            <div id="resultsContainer" class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-4 generic-items-container custom-scrollbar">
+                <p class="text-gray-500 italic col-span-full text-center">Search for media.</p>
             </div>
         </div>
 
@@ -407,19 +395,8 @@
                     </div>
                 </div>
             </div>
-            <div class="grid grid-cols-1 md:grid-cols-3 gap-8">
-                <div id="watchlistDisplayContainer" class="md:col-span-1 bg-gray-800 p-6 rounded-lg shadow-xl space-y-3 max-h-[calc(100vh-450px)] md:max-h-[70vh] overflow-y-auto pr-2">
-                    <p class="text-gray-500 italic col-span-full text-center">Select a watchlist or create one to view items.</p>
-                </div>
-                <div id="watchlistItemDetailPanel" class="md:col-span-2 bg-gray-800 p-6 rounded-lg shadow-xl min-h-[400px]">
-                    <div id="watchlistBackButtonContainer" class="mb-2"></div>
-                    <h2 id="watchlistDetailTitle" class="section-title">Details & Player</h2>
-                    <div id="watchlistDetailContainer"><p class="text-gray-500 italic">Select an item from your watchlist.</p></div>
-                    <div id="watchlistVidsrcPlayerSection" class="mt-4"></div>
-                    <div id="watchlistSeasonsEpisodesSection" class="mt-4"></div>
-                    <div id="watchlistRelatedItemsSection" class="mt-6"></div>
-                    <div id="watchlistCollectionItemsSection" class="mt-6"></div>
-                </div>
+            <div id="watchlistDisplayContainer" class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-4 generic-items-container custom-scrollbar">
+                <p class="text-gray-500 italic col-span-full text-center">Select a watchlist or create one to view items.</p>
             </div>
         </div>
 

--- a/ui.js
+++ b/ui.js
@@ -178,9 +178,19 @@ export function createBackButton(originContext) {
                 popularContentDisplay.scrollTop = scrollPositions.popular;
             }
         } else if (originContext === 'watchlistItemsList') {
-            clearItemDetailPanel('watchlist'); 
+            if (detailOverlay && !detailOverlay.classList.contains('hidden')) {
+                detailOverlay.classList.add('hidden');
+                clearItemDetailPanel('overlay');
+            } else {
+                clearItemDetailPanel('watchlist');
+            }
         } else if (originContext === 'searchList') {
-            clearItemDetailPanel('item'); // This will ONLY clear the item detail, search results are not touched here.
+            if (detailOverlay && !detailOverlay.classList.contains('hidden')) {
+                detailOverlay.classList.add('hidden');
+                clearItemDetailPanel('overlay');
+            } else {
+                clearItemDetailPanel('item'); // This will ONLY clear the item detail, search results are not touched here.
+            }
         }
         updatePreviousStateForBackButton(null);
     };
@@ -217,7 +227,8 @@ export function displayResults(items, itemType, resContainer) {
             <p class="text-[10px] text-gray-400">${year}</p>
             ${item.vote_average && item.vote_average > 0 ? `<p class="text-[10px] text-yellow-400">★ ${item.vote_average.toFixed(1)}</p>` : ''}
         `;
-        card.addEventListener('click', () => handleItemSelect(String(item.id), title, itemType));
+        // Open details in the overlay when selecting from search results
+        card.addEventListener('click', () => handleItemSelect(String(item.id), title, itemType, true));
         flexContainer.appendChild(card);
         appendSeenCheckmark(card, String(item.id)); 
     });

--- a/watchlist.js
+++ b/watchlist.js
@@ -272,7 +272,8 @@ export function createWatchlistItemCard(item) {
     `;
     const removeBtn = card.querySelector('.remove-watchlist-btn');
     removeBtn.addEventListener('click', (e) => { e.stopPropagation(); removeItemFromSpecificFirestoreWatchlist(currentSelectedWatchlistName, item.tmdb_id); });
-    card.addEventListener('click', () => { handleItemSelect(item.tmdb_id, item.title, item.item_type, false, true); });
+    // Use overlay for watchlist item details
+    card.addEventListener('click', () => { handleItemSelect(item.tmdb_id, item.title, item.item_type, true); });
     appendSeenCheckmark(card, item.tmdb_id); // From seenList.js
     return card;
 }


### PR DESCRIPTION
## Summary
- simplify Search and My Watchlists sections
- remove side‑panel details and show items in a grid
- rely on overlay for item details like other tabs

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68412f2205048323a68ca9f0d8b1610c