### PR TITLE
Clean up unused watchlist detail variables

### DIFF
--- a/handlers.js
+++ b/handlers.js
@@ -14,16 +14,16 @@ import {
 
 // DOM Elements
 let detailOverlay, detailOverlayContent, searchView, latestView, popularView, watchlistView,
-    tabLatest, tabPopular, 
+    tabLatest, tabPopular,
     latestContentDisplay, popularContentDisplay,
-    itemDetailTitle, overlayDetailTitle, watchlistItemDetailTitle,
-    itemDetailContainer, overlayDetailContainer, watchlistItemDetailContainer,
-    itemSeasonsEpisodesSection, overlaySeasonsEpisodesSection, watchlistSeasonsEpisodesSection,
-    itemRelatedItemsSection, overlayRelatedItemsSection, watchlistRelatedItemsSection,
-    itemCollectionItemsSection, overlayCollectionItemsSection, watchlistCollectionItemsSection,
-    itemVidsrcPlayerSection, overlayVidsrcPlayerSection, watchlistVidsrcPlayerSection,
-    itemBackButtonContainer, overlayBackButtonContainer, watchlistBackButtonContainer,
-    searchInputGlobal; 
+    itemDetailTitle, overlayDetailTitle,
+    itemDetailContainer, overlayDetailContainer,
+    itemSeasonsEpisodesSection, overlaySeasonsEpisodesSection,
+    itemRelatedItemsSection, overlayRelatedItemsSection,
+    itemCollectionItemsSection, overlayCollectionItemsSection,
+    itemVidsrcPlayerSection, overlayVidsrcPlayerSection,
+    itemBackButtonContainer, overlayBackButtonContainer,
+    searchInputGlobal;
 
 export function initHandlerRefs(elements) {
     detailOverlay = elements.detailOverlay;
@@ -38,26 +38,19 @@ export function initHandlerRefs(elements) {
     popularContentDisplay = elements.popularContentDisplay;
     itemDetailTitle = elements.itemDetailTitle;
     overlayDetailTitle = elements.overlayDetailTitle;
-    watchlistItemDetailTitle = elements.watchlistItemDetailTitle;
     itemDetailContainer = elements.itemDetailContainer;
     overlayDetailContainer = elements.overlayDetailContainer;
-    watchlistItemDetailContainer = elements.watchlistItemDetailContainer;
     itemSeasonsEpisodesSection = elements.itemSeasonsEpisodesSection;
     overlaySeasonsEpisodesSection = elements.overlaySeasonsEpisodesSection;
-    watchlistSeasonsEpisodesSection = elements.watchlistSeasonsEpisodesSection;
     itemRelatedItemsSection = elements.itemRelatedItemsSection;
     overlayRelatedItemsSection = elements.overlayRelatedItemsSection;
-    watchlistRelatedItemsSection = elements.watchlistRelatedItemsSection;
     itemCollectionItemsSection = elements.itemCollectionItemsSection;
     overlayCollectionItemsSection = elements.overlayCollectionItemsSection;
-    watchlistCollectionItemsSection = elements.watchlistCollectionItemsSection;
     itemVidsrcPlayerSection = elements.itemVidsrcPlayerSection;
     overlayVidsrcPlayerSection = elements.overlayVidsrcPlayerSection;
-    watchlistVidsrcPlayerSection = elements.watchlistVidsrcPlayerSection;
     itemBackButtonContainer = elements.itemBackButtonContainer;
     overlayBackButtonContainer = elements.overlayBackButtonContainer;
-    watchlistBackButtonContainer = elements.watchlistBackButtonContainer;
-    searchInputGlobal = elements.searchInput; 
+    searchInputGlobal = elements.searchInput;
 }
 
 
@@ -89,17 +82,19 @@ export async function handleItemSelect(itemId, itemTitle, itemType, calledFromGe
         if (detailOverlay) detailOverlay.classList.remove('hidden');
         if (detailOverlayContent) detailOverlayContent.scrollTop = 0;
 
-    } else if (calledFromWatchlistItem) { 
-        currentTargetViewContext = "watchlist";
-        currentDetailTitleEl = watchlistItemDetailTitle; // Assign correct title element
-        currentDetailContainerEl = watchlistItemDetailContainer;
-        currentSeasonsEl = watchlistSeasonsEpisodesSection;
-        currentRelatedEl = watchlistRelatedItemsSection;
-        currentCollectionEl = watchlistCollectionItemsSection;
-        currentPlayerEl = watchlistVidsrcPlayerSection;
-        currentBackButtonContainerEl = watchlistBackButtonContainer;
+    } else if (calledFromWatchlistItem) {
+        currentTargetViewContext = "overlay";
+        currentDetailTitleEl = overlayDetailTitle;
+        currentDetailContainerEl = overlayDetailContainer;
+        currentSeasonsEl = overlaySeasonsEpisodesSection;
+        currentRelatedEl = overlayRelatedItemsSection;
+        currentCollectionEl = overlayCollectionItemsSection;
+        currentPlayerEl = overlayVidsrcPlayerSection;
+        currentBackButtonContainerEl = overlayBackButtonContainer;
         updatePreviousStateForBackButton({ originTabId: 'tabWatchlist' });
-    } else { 
+        if (detailOverlay) detailOverlay.classList.remove('hidden');
+        if (detailOverlayContent) detailOverlayContent.scrollTop = 0;
+    } else {
         currentTargetViewContext = "item";
         currentDetailTitleEl = itemDetailTitle; // Assign correct title element
         currentDetailContainerEl = itemDetailContainer;
@@ -123,10 +118,12 @@ export async function handleItemSelect(itemId, itemTitle, itemType, calledFromGe
     if (currentBackButtonContainerEl) {
         currentBackButtonContainerEl.innerHTML = '';
         let backButtonContext;
-        if (currentTargetViewContext === 'overlay' && previousStateForBackButton) {
-            backButtonContext = previousStateForBackButton.originTabId === 'tabLatest' ? 'latestList' : 'popularList';
-        } else if (currentTargetViewContext === 'watchlist') {
-            backButtonContext = 'watchlistItemsList';
+        if (currentTargetViewContext === 'overlay') {
+            if (calledFromWatchlistItem) {
+                backButtonContext = 'watchlistItemsList';
+            } else if (previousStateForBackButton) {
+                backButtonContext = previousStateForBackButton.originTabId === 'tabLatest' ? 'latestList' : 'popularList';
+            }
         } else if (currentTargetViewContext === 'item') {
             backButtonContext = 'searchList';
         }
@@ -147,7 +144,7 @@ export async function handleItemSelect(itemId, itemTitle, itemType, calledFromGe
     });
 
     if (currentTargetViewContext !== "overlay") {
-        const detailSectionToScroll = document.getElementById(currentTargetViewContext === 'watchlist' ? 'watchlistItemDetailPanel' : 'itemDetailSection');
+        const detailSectionToScroll = document.getElementById('itemDetailSection');
         if (detailSectionToScroll) {
             detailSectionToScroll.scrollIntoView({ behavior: 'smooth', block: 'start' });
         }

--- a/main.js
+++ b/main.js
@@ -23,9 +23,10 @@ let searchInput, searchButton, resultsContainer, itemDetailContainer, itemDetail
     searchView, watchlistView, seenView, latestView, popularView,
     messageArea, newWatchlistNameInput, createWatchlistBtn,
     watchlistTilesContainer, watchlistDisplayContainer,
-    watchlistItemDetailPanel, watchlistItemDetailTitle, watchlistItemDetailContainer,
+    /* Deprecated watchlist detail variables removed */
+    /* watchlistItemDetailPanel, watchlistItemDetailTitle, watchlistItemDetailContainer,
     watchlistSeasonsEpisodesSection, watchlistRelatedItemsSection, watchlistCollectionItemsSection,
-    watchlistBackButtonContainer,
+    watchlistBackButtonContainer,*/
     seenItemsDisplayContainer,
     latestContentDisplay, latestMoviesSubTab, latestTvShowsSubTab,
     popularContentDisplay, popularMoviesSubTab, popularTvShowsSubTab,
@@ -36,7 +37,7 @@ let searchInput, searchButton, resultsContainer, itemDetailContainer, itemDetail
     overlaySeasonsEpisodesSection,
     overlayRelatedItemsSection, overlayCollectionItemsSection, overlayBackButtonContainer,
     positionIndicator,
-    itemVidsrcPlayerSection, watchlistVidsrcPlayerSection;
+    itemVidsrcPlayerSection;
 
 async function initializeAppState() {
     await loadFirebaseIfNeeded();
@@ -69,14 +70,7 @@ async function initializeAppState() {
     createWatchlistBtn = document.getElementById('createWatchlistBtn');
     watchlistTilesContainer = document.getElementById('watchlistTilesContainer');
     watchlistDisplayContainer = document.getElementById('watchlistDisplayContainer');
-    watchlistItemDetailPanel = document.getElementById('watchlistItemDetailPanel');
-    watchlistItemDetailTitle = document.getElementById('watchlistDetailTitle');
-    watchlistItemDetailContainer = document.getElementById('watchlistDetailContainer');
-    watchlistSeasonsEpisodesSection = document.getElementById('watchlistSeasonsEpisodesSection');
-    watchlistRelatedItemsSection = document.getElementById('watchlistRelatedItemsSection');
-    watchlistCollectionItemsSection = document.getElementById('watchlistCollectionItemsSection');
-    watchlistBackButtonContainer = document.getElementById('watchlistBackButtonContainer');
-    watchlistVidsrcPlayerSection = document.getElementById('watchlistVidsrcPlayerSection');
+    /* Removed obsolete watchlist detail queries */
 
     seenItemsDisplayContainer = document.getElementById('seenItemsDisplayContainer');
 
@@ -110,9 +104,6 @@ async function initializeAppState() {
         searchView, watchlistView, seenView, latestView, popularView,
         messageArea, newWatchlistNameInput, createWatchlistBtn,
         watchlistTilesContainer, watchlistDisplayContainer,
-        watchlistItemDetailPanel, watchlistItemDetailTitle, watchlistItemDetailContainer,
-        watchlistSeasonsEpisodesSection, watchlistRelatedItemsSection, watchlistCollectionItemsSection,
-        watchlistBackButtonContainer,
         seenItemsDisplayContainer,
         latestContentDisplay, latestMoviesSubTab, latestTvShowsSubTab,
         popularContentDisplay, popularMoviesSubTab, popularTvShowsSubTab,
@@ -122,7 +113,7 @@ async function initializeAppState() {
         overlayVidsrcPlayerSection, 
         overlaySeasonsEpisodesSection,
         overlayRelatedItemsSection, overlayCollectionItemsSection, overlayBackButtonContainer,
-        positionIndicator, itemVidsrcPlayerSection, watchlistVidsrcPlayerSection
+        positionIndicator, itemVidsrcPlayerSection
     };
 
     initUiRefs(allElements);

--- a/seenList.js
+++ b/seenList.js
@@ -204,11 +204,6 @@ export async function updateMarkAsSeenButtonState(itemId, itemData, buttonContai
 
 export function determineActiveSeenButtonContainerId() {
     const detailOverlayEl = document.getElementById('detailOverlay');
-    const watchlistViewEl = document.getElementById('watchlistView');
-    const watchlistItemDetailPanelEl = document.getElementById('watchlistItemDetailPanel');
-
     if (detailOverlayEl && !detailOverlayEl.classList.contains('hidden')) return 'overlayDetailMarkAsSeenBtnContainer';
-    if (watchlistViewEl && !watchlistViewEl.classList.contains('hidden-view') &&
-        watchlistItemDetailPanelEl && !watchlistItemDetailPanelEl.classList.contains('hidden')) return 'watchlistDetailMarkAsSeenBtnContainer';
     return 'itemDetailMarkAsSeenBtnContainer';
 }

--- a/ui.js
+++ b/ui.js
@@ -16,12 +16,10 @@ import { handleItemSelect } from './handlers.js';
 // DOM Elements (initialized in main.js)
 let messageArea, resultsContainer, itemDetailContainer, itemDetailTitle,
     itemSeasonsEpisodesSection, itemRelatedItemsSection, itemCollectionItemsSection, itemBackButtonContainer,
-    watchlistItemDetailContainer, watchlistItemDetailTitle, watchlistSeasonsEpisodesSection,
-    watchlistRelatedItemsSection, watchlistCollectionItemsSection, watchlistBackButtonContainer,
     overlayDetailContainer, overlayDetailTitle, overlaySeasonsEpisodesSection,
     overlayRelatedItemsSection, overlayCollectionItemsSection, overlayBackButtonContainer,
     detailOverlay, detailOverlayContent, positionIndicator,
-    itemVidsrcPlayerSection, watchlistVidsrcPlayerSection, overlayVidsrcPlayerSection,
+    itemVidsrcPlayerSection, overlayVidsrcPlayerSection,
     latestContentDisplay, popularContentDisplay;
 
 
@@ -34,12 +32,6 @@ export function initUiRefs(elements) {
     itemRelatedItemsSection = elements.itemRelatedItemsSection;
     itemCollectionItemsSection = elements.itemCollectionItemsSection;
     itemBackButtonContainer = elements.itemBackButtonContainer;
-    watchlistItemDetailContainer = elements.watchlistItemDetailContainer;
-    watchlistItemDetailTitle = elements.watchlistItemDetailTitle;
-    watchlistSeasonsEpisodesSection = elements.watchlistSeasonsEpisodesSection;
-    watchlistRelatedItemsSection = elements.watchlistRelatedItemsSection;
-    watchlistCollectionItemsSection = elements.watchlistCollectionItemsSection;
-    watchlistBackButtonContainer = elements.watchlistBackButtonContainer;
     overlayDetailContainer = elements.overlayDetailContainer;
     overlayDetailTitle = elements.overlayDetailTitle;
     overlaySeasonsEpisodesSection = elements.overlaySeasonsEpisodesSection;
@@ -50,9 +42,8 @@ export function initUiRefs(elements) {
     detailOverlayContent = elements.detailOverlayContent;
     positionIndicator = elements.positionIndicator;
     itemVidsrcPlayerSection = elements.itemVidsrcPlayerSection;
-    watchlistVidsrcPlayerSection = elements.watchlistVidsrcPlayerSection;
     overlayVidsrcPlayerSection = elements.overlayVidsrcPlayerSection;
-    latestContentDisplay = elements.latestContentDisplay; 
+    latestContentDisplay = elements.latestContentDisplay;
     popularContentDisplay = elements.popularContentDisplay;
 }
 
@@ -72,7 +63,6 @@ export function showLoading(section = 'main', text = 'Loading...', targetElement
     if (!target) { 
         if (section === 'results') target = resultsContainer;
         else if (section === 'details-item') target = itemDetailContainer;
-        else if (section === 'details-watchlist') target = watchlistItemDetailContainer;
         else if (section === 'details-overlay') target = overlayDetailContainer;
         else if (section === 'watchlistItems') target = document.getElementById('watchlistDisplayContainer'); 
         else if (section === 'seenItemsDisplayContainer') target = document.getElementById('seenItemsDisplayContainer'); 
@@ -89,7 +79,6 @@ export function showMessage(message, type = 'info', section = 'main', targetElem
     if (!target) { 
       if (section === 'results') target = resultsContainer;
       else if (section === 'details-item') target = itemDetailContainer;
-      else if (section === 'details-watchlist') target = watchlistItemDetailContainer;
       else if (section === 'details-overlay') target = overlayDetailContainer;
       else if (section === 'watchlistItems') target = document.getElementById('watchlistDisplayContainer');
       else if (section === 'seenItemsDisplayContainer') target = document.getElementById('seenItemsDisplayContainer');
@@ -373,8 +362,7 @@ export function displaySeasons(seasons, parentShowTmdbId, parentShowImdbId, targ
             const episodeDisplayContainer = document.getElementById(`${targetViewContext}EpisodeDisplayContainer`);
             let playerSection;
             if (targetViewContext === "item") playerSection = itemVidsrcPlayerSection;
-            else if (targetViewContext === "watchlist") playerSection = watchlistVidsrcPlayerSection;
-            else if (targetViewContext === "overlay") playerSection = overlayVidsrcPlayerSection;
+            else playerSection = overlayVidsrcPlayerSection;
 
             fetchEpisodesForSeason(parentShowTmdbId, s.season_number, parentShowImdbId, episodeDisplayContainer, targetViewContext, playerSection);
 
@@ -405,8 +393,7 @@ export function createRelatedItemCard(item, itemType, currentViewContext = "item
     `;
     card.addEventListener('click', () => {
         const calledFromOverlay = currentViewContext === 'overlay';
-        const calledFromWatchlist = currentViewContext === 'watchlist';
-        handleItemSelect(String(item.id), item.title || item.name, itemType, calledFromOverlay, calledFromWatchlist);
+        handleItemSelect(String(item.id), item.title || item.name, itemType, calledFromOverlay);
     });
     appendSeenCheckmark(card, String(item.id)); 
     return card;

--- a/watchlist.js
+++ b/watchlist.js
@@ -493,11 +493,8 @@ export function closeAllOptionMenus(exceptThisTile = null) {
 }
 
 export function determineActiveWatchlistButtonContainerId() {
-    const detailOverlayEl = document.getElementById('detailOverlay'); // Get element
-    const watchlistViewEl = document.getElementById('watchlistView'); // Get element
-
+    const detailOverlayEl = document.getElementById('detailOverlay');
     if (detailOverlayEl && !detailOverlayEl.classList.contains('hidden')) return 'overlayDetailAddToBtnContainer';
-    if (watchlistViewEl && !watchlistViewEl.classList.contains('hidden-view')) return 'watchlistDetailAddToBtnContainer';
     return 'itemDetailAddToBtnContainer';
 }
 


### PR DESCRIPTION
## Summary
- remove legacy watchlist detail queries from `main.js`
- drop watchlist detail refs from handlers and UI helpers
- simplify seen and watchlist helpers to use overlay only

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68414ff3a640832398fec7759ab194da