### PR TITLE
Remove unused detail panel code

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,9 +13,7 @@
         .related-movies-scroll::-webkit-scrollbar, .episodes-list::-webkit-scrollbar,
         .seasons-list::-webkit-scrollbar, .overview-scroll::-webkit-scrollbar,
         #watchlistTilesContainer::-webkit-scrollbar, .generic-items-container::-webkit-scrollbar,
-        #watchlistManagePopupList::-webkit-scrollbar, #watchlistItemDetailContainer::-webkit-scrollbar,
-        #watchlistSeasonsEpisodesSection::-webkit-scrollbar, #watchlistRelatedItemsSection::-webkit-scrollbar,
-        #watchlistCollectionItemsSection::-webkit-scrollbar,
+        #watchlistManagePopupList::-webkit-scrollbar,
         #overlayDetailContainer::-webkit-scrollbar, .overlay-content-scroll::-webkit-scrollbar,
         .custom-scrollbar::-webkit-scrollbar {
             width: 8px; height: 8px;
@@ -24,9 +22,7 @@
         .related-movies-scroll::-webkit-scrollbar-track, .episodes-list::-webkit-scrollbar-track,
         .seasons-list::-webkit-scrollbar-track, .overview-scroll::-webkit-scrollbar-track,
         #watchlistTilesContainer::-webkit-scrollbar-track, .generic-items-container::-webkit-scrollbar-track,
-        #watchlistManagePopupList::-webkit-scrollbar-track, #watchlistItemDetailContainer::-webkit-scrollbar-track,
-        #watchlistSeasonsEpisodesSection::-webkit-scrollbar-track, #watchlistRelatedItemsSection::-webkit-scrollbar-track,
-        #watchlistCollectionItemsSection::-webkit-scrollbar-track,
+        #watchlistManagePopupList::-webkit-scrollbar-track,
         #overlayDetailContainer::-webkit-scrollbar-track, .overlay-content-scroll::-webkit-scrollbar-track,
         .custom-scrollbar::-webkit-scrollbar-track {
             background: #374151; border-radius: 10px;
@@ -35,9 +31,7 @@
         .related-movies-scroll::-webkit-scrollbar-thumb, .episodes-list::-webkit-scrollbar-thumb,
         .seasons-list::-webkit-scrollbar-thumb, .overview-scroll::-webkit-scrollbar-thumb,
         #watchlistTilesContainer::-webkit-scrollbar-thumb, .generic-items-container::-webkit-scrollbar-thumb,
-        #watchlistManagePopupList::-webkit-scrollbar-thumb, #watchlistItemDetailContainer::-webkit-scrollbar-thumb,
-        #watchlistSeasonsEpisodesSection::-webkit-scrollbar-thumb, #watchlistRelatedItemsSection::-webkit-scrollbar-thumb,
-        #watchlistCollectionItemsSection::-webkit-scrollbar-thumb,
+        #watchlistManagePopupList::-webkit-scrollbar-thumb,
         #overlayDetailContainer::-webkit-scrollbar-thumb, .overlay-content-scroll::-webkit-scrollbar-thumb,
         .custom-scrollbar::-webkit-scrollbar-thumb {
             background: #6b7280; border-radius: 10px;
@@ -46,9 +40,7 @@
         .related-movies-scroll::-webkit-scrollbar-thumb:hover, .episodes-list::-webkit-scrollbar-thumb:hover,
         .seasons-list::-webkit-scrollbar-thumb:hover, .overview-scroll::-webkit-scrollbar-thumb:hover,
         #watchlistTilesContainer::-webkit-scrollbar-thumb:hover, .generic-items-container::-webkit-scrollbar-thumb:hover,
-        #watchlistManagePopupList::-webkit-scrollbar-thumb:hover, #watchlistItemDetailContainer::-webkit-scrollbar-thumb:hover,
-        #watchlistSeasonsEpisodesSection::-webkit-scrollbar-thumb:hover, #watchlistRelatedItemsSection::-webkit-scrollbar-thumb:hover,
-        #watchlistCollectionItemsSection::-webkit-scrollbar-thumb:hover,
+        #watchlistManagePopupList::-webkit-scrollbar-thumb:hover,
         #overlayDetailContainer::-webkit-scrollbar-thumb:hover, .overlay-content-scroll::-webkit-scrollbar-thumb:hover,
         .custom-scrollbar::-webkit-scrollbar-thumb:hover {
             background: #9ca3af;

--- a/main.js
+++ b/main.js
@@ -17,16 +17,11 @@ import {
 window.createAuthFormUI_Global = createAuthFormUI;
 
 // DOM Element Variables
-let searchInput, searchButton, resultsContainer, itemDetailContainer, itemDetailTitle,
-    itemSeasonsEpisodesSection, itemRelatedItemsSection, itemCollectionItemsSection, itemBackButtonContainer,
+let searchInput, searchButton, resultsContainer,
     tabSearch, tabWatchlist, tabSeen, tabLatest, tabPopular,
     searchView, watchlistView, seenView, latestView, popularView,
     messageArea, newWatchlistNameInput, createWatchlistBtn,
     watchlistTilesContainer, watchlistDisplayContainer,
-    /* Deprecated watchlist detail variables removed */
-    /* watchlistItemDetailPanel, watchlistItemDetailTitle, watchlistItemDetailContainer,
-    watchlistSeasonsEpisodesSection, watchlistRelatedItemsSection, watchlistCollectionItemsSection,
-    watchlistBackButtonContainer,*/
     seenItemsDisplayContainer,
     latestContentDisplay, latestMoviesSubTab, latestTvShowsSubTab,
     popularContentDisplay, popularMoviesSubTab, popularTvShowsSubTab,
@@ -46,12 +41,6 @@ async function initializeAppState() {
     searchInput = document.getElementById('searchInput');
     searchButton = document.getElementById('searchButton');
     resultsContainer = document.getElementById('resultsContainer');
-    itemDetailContainer = document.getElementById('itemDetailContainer');
-    itemDetailTitle = document.getElementById('itemDetailTitle');
-    itemSeasonsEpisodesSection = document.getElementById('itemSeasonsEpisodesSection');
-    itemRelatedItemsSection = document.getElementById('itemRelatedItemsSection');
-    itemCollectionItemsSection = document.getElementById('itemCollectionItemsSection');
-    itemBackButtonContainer = document.getElementById('itemBackButtonContainer');
     itemVidsrcPlayerSection = document.getElementById('itemVidsrcPlayerSection');
 
     tabSearch = document.getElementById('tabSearch');
@@ -98,8 +87,7 @@ async function initializeAppState() {
     positionIndicator = document.getElementById('positionIndicator');
 
     const allElements = {
-        searchInput, searchButton, resultsContainer, itemDetailContainer, itemDetailTitle,
-        itemSeasonsEpisodesSection, itemRelatedItemsSection, itemCollectionItemsSection, itemBackButtonContainer,
+        searchInput, searchButton, resultsContainer,
         tabSearch, tabWatchlist, tabSeen, tabLatest, tabPopular,
         searchView, watchlistView, seenView, latestView, popularView,
         messageArea, newWatchlistNameInput, createWatchlistBtn,

--- a/ui.js
+++ b/ui.js
@@ -14,8 +14,7 @@ import { updateMarkAsSeenButtonState, appendSeenCheckmark } from './seenList.js'
 import { handleItemSelect } from './handlers.js';
 
 // DOM Elements (initialized in main.js)
-let messageArea, resultsContainer, itemDetailContainer, itemDetailTitle,
-    itemSeasonsEpisodesSection, itemRelatedItemsSection, itemCollectionItemsSection, itemBackButtonContainer,
+let messageArea, resultsContainer,
     overlayDetailContainer, overlayDetailTitle, overlaySeasonsEpisodesSection,
     overlayRelatedItemsSection, overlayCollectionItemsSection, overlayBackButtonContainer,
     detailOverlay, detailOverlayContent, positionIndicator,
@@ -26,12 +25,6 @@ let messageArea, resultsContainer, itemDetailContainer, itemDetailTitle,
 export function initUiRefs(elements) {
     messageArea = elements.messageArea;
     resultsContainer = elements.resultsContainer;
-    itemDetailContainer = elements.itemDetailContainer;
-    itemDetailTitle = elements.itemDetailTitle;
-    itemSeasonsEpisodesSection = elements.itemSeasonsEpisodesSection;
-    itemRelatedItemsSection = elements.itemRelatedItemsSection;
-    itemCollectionItemsSection = elements.itemCollectionItemsSection;
-    itemBackButtonContainer = elements.itemBackButtonContainer;
     overlayDetailContainer = elements.overlayDetailContainer;
     overlayDetailTitle = elements.overlayDetailTitle;
     overlaySeasonsEpisodesSection = elements.overlaySeasonsEpisodesSection;
@@ -62,7 +55,6 @@ export function showLoading(section = 'main', text = 'Loading...', targetElement
     let target = targetElement; 
     if (!target) { 
         if (section === 'results') target = resultsContainer;
-        else if (section === 'details-item') target = itemDetailContainer;
         else if (section === 'details-overlay') target = overlayDetailContainer;
         else if (section === 'watchlistItems') target = document.getElementById('watchlistDisplayContainer'); 
         else if (section === 'seenItemsDisplayContainer') target = document.getElementById('seenItemsDisplayContainer'); 
@@ -78,7 +70,6 @@ export function showMessage(message, type = 'info', section = 'main', targetElem
     let target = targetElement; 
     if (!target) { 
       if (section === 'results') target = resultsContainer;
-      else if (section === 'details-item') target = itemDetailContainer;
       else if (section === 'details-overlay') target = overlayDetailContainer;
       else if (section === 'watchlistItems') target = document.getElementById('watchlistDisplayContainer');
       else if (section === 'seenItemsDisplayContainer') target = document.getElementById('seenItemsDisplayContainer');
@@ -206,7 +197,7 @@ export function displayResults(items, itemType, resContainer) {
             <p class="text-[10px] text-gray-400">${year}</p>
             ${item.vote_average && item.vote_average > 0 ? `<p class="text-[10px] text-yellow-400">★ ${item.vote_average.toFixed(1)}</p>` : ''}
         `;
-        card.addEventListener('click', () => handleItemSelect(String(item.id), title, itemType));
+        card.addEventListener('click', () => handleItemSelect(String(item.id), title, itemType, true));
         flexContainer.appendChild(card);
         appendSeenCheckmark(card, String(item.id)); 
     });

--- a/watchlist.js
+++ b/watchlist.js
@@ -272,7 +272,7 @@ export function createWatchlistItemCard(item) {
     `;
     const removeBtn = card.querySelector('.remove-watchlist-btn');
     removeBtn.addEventListener('click', (e) => { e.stopPropagation(); removeItemFromSpecificFirestoreWatchlist(currentSelectedWatchlistName, item.tmdb_id); });
-    card.addEventListener('click', () => { handleItemSelect(item.tmdb_id, item.title, item.item_type, false, true); });
+    card.addEventListener('click', () => { handleItemSelect(item.tmdb_id, item.title, item.item_type, true); });
     appendSeenCheckmark(card, item.tmdb_id); // From seenList.js
     return card;
 }


### PR DESCRIPTION
## Summary
- delete obsolete non-overlay watchlist/item detail elements
- update handlers to only support overlay detail panel
- clean up UI helpers and event calls
- simplify CSS definitions for removed watchlist detail sections

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684153bbae6883239f8fa59159a1e39e