### PR TITLE
Add rating filter to search

### DIFF
--- a/api.js
+++ b/api.js
@@ -27,10 +27,18 @@ export function initApiRefs(elements) {
 }
 
 
-export async function fetchSearchResults(query, itemType) {
+export function buildSearchUrl(query, itemType, certification) {
+    let url = `${tmdbBaseUrl}/search/${itemType}?api_key=${apiKey}&query=${encodeURIComponent(query)}&include_adult=false`;
+    if (certification && certification !== 'All') {
+        url += `&certification_country=US&certification=${encodeURIComponent(certification)}`;
+    }
+    return url;
+}
+
+export async function fetchSearchResults(query, itemType, certification) {
     showLoading('results', `Searching for "${query}"...`, resultsContainer);
     try {
-        const response = await fetch(`${tmdbBaseUrl}/search/${itemType}?api_key=${apiKey}&query=${encodeURIComponent(query)}&include_adult=false`);
+        const response = await fetch(buildSearchUrl(query, itemType, certification));
         if (!response.ok) throw new Error(`API Error: ${response.statusText}`);
         const data = await response.json();
         if (data.results && data.results.length > 0) {

--- a/handlers.js
+++ b/handlers.js
@@ -9,7 +9,8 @@ import {
 } from './ui.js';
 import {
     previousStateForBackButton, updatePreviousStateForBackButton,
-    scrollPositions, updateScrollPosition
+    scrollPositions, updateScrollPosition,
+    updateSelectedCertification
 } from './state.js';
 
 // DOM Elements
@@ -20,7 +21,8 @@ let detailOverlay, detailOverlayContent, searchView, latestView, popularView, wa
     overlaySeasonsEpisodesSection, overlayRelatedItemsSection,
     overlayCollectionItemsSection, overlayVidsrcPlayerSection,
     overlayBackButtonContainer,
-    searchInputGlobal;
+    searchInputGlobal,
+    ratingFilterGlobal;
 
 export function initHandlerRefs(elements) {
     detailOverlay = elements.detailOverlay;
@@ -41,6 +43,7 @@ export function initHandlerRefs(elements) {
     overlayVidsrcPlayerSection = elements.overlayVidsrcPlayerSection;
     overlayBackButtonContainer = elements.overlayBackButtonContainer;
     searchInputGlobal = elements.searchInput;
+    ratingFilterGlobal = elements.ratingFilter;
 }
 
 
@@ -111,11 +114,13 @@ export async function handleSearch() {
     if (!searchInputGlobal) { console.error("Search input not initialized in handlers.js"); return; }
     const query = searchInputGlobal.value.trim();
     const itemType = getSelectedSearchType();
+    const rating = ratingFilterGlobal ? ratingFilterGlobal.value : 'All';
+    updateSelectedCertification(rating);
     if (!query) {
         showToast("Please enter a title.", "error"); // Ensure showToast is available
         return;
     }
     clearItemDetailPanel("item");      // Clear previous item details
     clearSearchResultsPanel();      // Explicitly clear search results for a new search
-    await fetchSearchResults(query, itemType);
+    await fetchSearchResults(query, itemType, rating);
 }

--- a/index.html
+++ b/index.html
@@ -363,6 +363,14 @@
                 </div>
                 <div class="flex flex-col sm:flex-row gap-4">
                     <input type="text" id="searchInput" placeholder="Enter title (e.g., Inception, Breaking Bad)" class="flex-grow p-3 bg-gray-700 text-white border border-gray-600 rounded-lg focus:ring-2 focus:ring-sky-500 focus:border-sky-500 outline-none">
+                    <select id="ratingFilter" class="p-3 bg-gray-700 text-white border border-gray-600 rounded-lg focus:ring-2 focus:ring-sky-500 focus:border-sky-500 outline-none">
+                        <option value="All">All</option>
+                        <option value="G">G</option>
+                        <option value="PG">PG</option>
+                        <option value="PG-13">PG-13</option>
+                        <option value="R">R</option>
+                        <option value="NC-17">NC-17</option>
+                    </select>
                     <button id="searchButton" class="bg-sky-500 hover:bg-sky-600 text-white font-semibold py-3 px-6 rounded-lg transition duration-200 shadow-md hover:shadow-lg">Search</button>
                 </div>
             </div>

--- a/main.js
+++ b/main.js
@@ -17,7 +17,7 @@ import {
 window.createAuthFormUI_Global = createAuthFormUI;
 
 // DOM Element Variables
-let searchInput, searchButton, resultsContainer,
+let searchInput, ratingFilter, searchButton, resultsContainer,
     tabSearch, tabWatchlist, tabSeen, tabLatest, tabPopular,
     searchView, watchlistView, seenView, latestView, popularView,
     messageArea, newWatchlistNameInput, createWatchlistBtn,
@@ -39,6 +39,7 @@ async function initializeAppState() {
 
     // Assign DOM Elements
     searchInput = document.getElementById('searchInput');
+    ratingFilter = document.getElementById('ratingFilter');
     searchButton = document.getElementById('searchButton');
     resultsContainer = document.getElementById('resultsContainer');
     itemVidsrcPlayerSection = document.getElementById('itemVidsrcPlayerSection');
@@ -88,7 +89,7 @@ async function initializeAppState() {
     positionIndicator = document.getElementById('positionIndicator');
 
     const allElements = {
-        searchInput, searchButton, resultsContainer,
+        searchInput, ratingFilter, searchButton, resultsContainer,
         tabSearch, tabWatchlist, tabSeen, tabLatest, tabPopular,
         searchView, watchlistView, seenView, latestView, popularView,
         messageArea, newWatchlistNameInput, createWatchlistBtn,

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "keywords": [],
   "author": "",
   "license": "ISC",
-  "type": "commonjs",
+  "type": "module",
   "devDependencies": {
     "jest": "^29.7.0"
   },

--- a/state.js
+++ b/state.js
@@ -10,6 +10,7 @@ export let currentPopularPage = 1;
 export let currentPopularType = 'movie';
 export let previousStateForBackButton = null;
 export let scrollPositions = { latest: 0, popular: 0 };
+export let selectedCertification = 'All';
 
 // Functions to update state
 export function updateCurrentSelectedItemDetails(details) {
@@ -28,6 +29,7 @@ export function updatePopularPage(page) { currentPopularPage = page; }
 export function updatePopularType(type) { currentPopularType = type; }
 export function updatePreviousStateForBackButton(state) { previousStateForBackButton = state; }
 export function updateScrollPosition(type, position) { scrollPositions[type] = position; }
+export function updateSelectedCertification(cert) { selectedCertification = cert; }
 
 // Active season cards (previously window properties)
 export let itemActiveSeasonCard = null;

--- a/tests/api-url.test.js
+++ b/tests/api-url.test.js
@@ -1,0 +1,8 @@
+import { buildSearchUrl } from '../api.js';
+
+describe('buildSearchUrl', () => {
+  test('includes certification when provided', () => {
+    const url = buildSearchUrl('test', 'movie', 'PG-13');
+    expect(url).toContain('certification=PG-13');
+  });
+});


### PR DESCRIPTION
## Summary
- add certification select dropdown to UI
- store chosen rating in state
- filter search requests using the rating
- update handler to pass rating option
- support ES module loading for Jest
- test that search URL includes certification parameter

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68415e15589c8323a546d2bf3922a7c3