### PR TITLE
Add multi-select rating filter

### DIFF
--- a/api.js
+++ b/api.js
@@ -27,18 +27,19 @@ export function initApiRefs(elements) {
 }
 
 
-export function buildSearchUrl(query, itemType, certification) {
+export function buildSearchUrl(query, itemType, certifications = []) {
     let url = `${tmdbBaseUrl}/search/${itemType}?api_key=${apiKey}&query=${encodeURIComponent(query)}&include_adult=false`;
-    if (certification && certification !== 'All') {
-        url += `&certification_country=US&certification=${encodeURIComponent(certification)}`;
+    if (certifications && certifications.length > 0 && !(certifications.length === 1 && certifications[0] === 'All')) {
+        const joined = certifications.join('|');
+        url += `&certification_country=US&certification=${encodeURIComponent(joined)}`;
     }
     return url;
 }
 
-export async function fetchSearchResults(query, itemType, certification) {
+export async function fetchSearchResults(query, itemType, certifications = []) {
     showLoading('results', `Searching for "${query}"...`, resultsContainer);
     try {
-        const response = await fetch(buildSearchUrl(query, itemType, certification));
+        const response = await fetch(buildSearchUrl(query, itemType, certifications));
         if (!response.ok) throw new Error(`API Error: ${response.statusText}`);
         const data = await response.json();
         if (data.results && data.results.length > 0) {

--- a/handlers.js
+++ b/handlers.js
@@ -10,7 +10,7 @@ import {
 import {
     previousStateForBackButton, updatePreviousStateForBackButton,
     scrollPositions, updateScrollPosition,
-    updateSelectedCertification
+    updateSelectedCertifications
 } from './state.js';
 
 // DOM Elements
@@ -22,7 +22,7 @@ let detailOverlay, detailOverlayContent, searchView, latestView, popularView, wa
     overlayCollectionItemsSection, overlayVidsrcPlayerSection,
     overlayBackButtonContainer,
     searchInputGlobal,
-    ratingFilterGlobal;
+    ratingFilterGlobals;
 
 export function initHandlerRefs(elements) {
     detailOverlay = elements.detailOverlay;
@@ -43,7 +43,7 @@ export function initHandlerRefs(elements) {
     overlayVidsrcPlayerSection = elements.overlayVidsrcPlayerSection;
     overlayBackButtonContainer = elements.overlayBackButtonContainer;
     searchInputGlobal = elements.searchInput;
-    ratingFilterGlobal = elements.ratingFilter;
+    ratingFilterGlobals = elements.ratingFilters;
 }
 
 
@@ -114,13 +114,14 @@ export async function handleSearch() {
     if (!searchInputGlobal) { console.error("Search input not initialized in handlers.js"); return; }
     const query = searchInputGlobal.value.trim();
     const itemType = getSelectedSearchType();
-    const rating = ratingFilterGlobal ? ratingFilterGlobal.value : 'All';
-    updateSelectedCertification(rating);
+    const ratingSelect = document.getElementById('ratingFilterSearch');
+    const selected = ratingSelect ? Array.from(ratingSelect.selectedOptions).map(o => o.value) : ['All'];
+    updateSelectedCertifications(selected);
     if (!query) {
         showToast("Please enter a title.", "error"); // Ensure showToast is available
         return;
     }
     clearItemDetailPanel("item");      // Clear previous item details
     clearSearchResultsPanel();      // Explicitly clear search results for a new search
-    await fetchSearchResults(query, itemType, rating);
+    await fetchSearchResults(query, itemType, selected);
 }

--- a/index.html
+++ b/index.html
@@ -363,7 +363,7 @@
                 </div>
                 <div class="flex flex-col sm:flex-row gap-4">
                     <input type="text" id="searchInput" placeholder="Enter title (e.g., Inception, Breaking Bad)" class="flex-grow p-3 bg-gray-700 text-white border border-gray-600 rounded-lg focus:ring-2 focus:ring-sky-500 focus:border-sky-500 outline-none">
-                    <select id="ratingFilter" class="p-3 bg-gray-700 text-white border border-gray-600 rounded-lg focus:ring-2 focus:ring-sky-500 focus:border-sky-500 outline-none">
+                    <select id="ratingFilterSearch" class="rating-filter p-3 bg-gray-700 text-white border border-gray-600 rounded-lg focus:ring-2 focus:ring-sky-500 focus:border-sky-500 outline-none" multiple>
                         <option value="All">All</option>
                         <option value="G">G</option>
                         <option value="PG">PG</option>
@@ -394,6 +394,14 @@
                     <div id="watchlistTilesContainer" class="flex flex-wrap gap-3 mb-3 p-1">
                         <p class="text-xs text-gray-400 col-span-full w-full text-center">Sign in to manage watchlists.</p>
                     </div>
+                    <select id="ratingFilterWatchlist" class="rating-filter p-2 bg-gray-700 text-white border border-gray-600 rounded-md focus:ring-2 focus:ring-sky-500 focus:border-sky-500 outline-none" multiple>
+                        <option value="All">All</option>
+                        <option value="G">G</option>
+                        <option value="PG">PG</option>
+                        <option value="PG-13">PG-13</option>
+                        <option value="R">R</option>
+                        <option value="NC-17">NC-17</option>
+                    </select>
                 </div>
             </div>
             <div id="watchlistDisplayContainer" class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-4 generic-items-container custom-scrollbar">
@@ -403,6 +411,14 @@
 
         <div id="seenView" class="hidden-view bg-gray-800 p-6 rounded-lg shadow-xl">
             <h2 class="section-title">Seen Items</h2>
+            <select id="ratingFilterSeen" class="rating-filter mb-4 p-2 bg-gray-700 text-white border border-gray-600 rounded-md focus:ring-2 focus:ring-sky-500 focus:border-sky-500 outline-none" multiple>
+                <option value="All">All</option>
+                <option value="G">G</option>
+                <option value="PG">PG</option>
+                <option value="PG-13">PG-13</option>
+                <option value="R">R</option>
+                <option value="NC-17">NC-17</option>
+            </select>
             <div id="seenItemsDisplayContainer" class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-4 generic-items-container custom-scrollbar">
                 <p class="text-gray-500 italic col-span-full text-center">No items marked as seen yet.</p>
             </div>
@@ -415,6 +431,14 @@
                     <button id="latestTvShowsSubTab" class="sub-tab" data-type="tv" data-category="airing_today">Airing Today TV</button>
                 </div>
             </div>
+            <select id="ratingFilterLatest" class="rating-filter mb-4 p-2 bg-gray-700 text-white border border-gray-600 rounded-md focus:ring-2 focus:ring-sky-500 focus:border-sky-500 outline-none" multiple>
+                <option value="All">All</option>
+                <option value="G">G</option>
+                <option value="PG">PG</option>
+                <option value="PG-13">PG-13</option>
+                <option value="R">R</option>
+                <option value="NC-17">NC-17</option>
+            </select>
             <div id="latestContentDisplay" class="space-y-4 custom-scrollbar"></div>
         </div>
 
@@ -425,6 +449,14 @@
                     <button id="popularTvShowsSubTab" class="sub-tab" data-type="tv" data-category="popular">Popular TV Shows</button>
                 </div>
             </div>
+            <select id="ratingFilterPopular" class="rating-filter mb-4 p-2 bg-gray-700 text-white border border-gray-600 rounded-md focus:ring-2 focus:ring-sky-500 focus:border-sky-500 outline-none" multiple>
+                <option value="All">All</option>
+                <option value="G">G</option>
+                <option value="PG">PG</option>
+                <option value="PG-13">PG-13</option>
+                <option value="R">R</option>
+                <option value="NC-17">NC-17</option>
+            </select>
              <div id="popularContentDisplay" class="space-y-4 custom-scrollbar"></div>
         </div>
 

--- a/main.js
+++ b/main.js
@@ -11,13 +11,14 @@ import {
     currentLatestType, currentLatestCategory, updateLatestPage, updateLatestType, updateLatestCategory,
     currentPopularType, updatePopularPage, updatePopularType, 
     previousStateForBackButton, updatePreviousStateForBackButton,
-    scrollPositions // Removed updateScrollPosition as it's used internally in handlers/state
+    scrollPositions, // Removed updateScrollPosition as it's used internally in handlers/state
+    updateSelectedCertifications
 } from './state.js';
 
 window.createAuthFormUI_Global = createAuthFormUI;
 
 // DOM Element Variables
-let searchInput, ratingFilter, searchButton, resultsContainer,
+let searchInput, ratingFilters, searchButton, resultsContainer,
     tabSearch, tabWatchlist, tabSeen, tabLatest, tabPopular,
     searchView, watchlistView, seenView, latestView, popularView,
     messageArea, newWatchlistNameInput, createWatchlistBtn,
@@ -39,7 +40,7 @@ async function initializeAppState() {
 
     // Assign DOM Elements
     searchInput = document.getElementById('searchInput');
-    ratingFilter = document.getElementById('ratingFilter');
+    ratingFilters = document.querySelectorAll('.rating-filter');
     searchButton = document.getElementById('searchButton');
     resultsContainer = document.getElementById('resultsContainer');
     itemVidsrcPlayerSection = document.getElementById('itemVidsrcPlayerSection');
@@ -89,7 +90,7 @@ async function initializeAppState() {
     positionIndicator = document.getElementById('positionIndicator');
 
     const allElements = {
-        searchInput, ratingFilter, searchButton, resultsContainer,
+        searchInput, ratingFilters, searchButton, resultsContainer,
         tabSearch, tabWatchlist, tabSeen, tabLatest, tabPopular,
         searchView, watchlistView, seenView, latestView, popularView,
         messageArea, newWatchlistNameInput, createWatchlistBtn,
@@ -123,6 +124,17 @@ async function initializeAppState() {
     if (searchInput) searchInput.addEventListener('keypress', (e) => { if (e.key === 'Enter') handleSearch(); });
 
     if (createWatchlistBtn) createWatchlistBtn.addEventListener('click', handleCreateWatchlist);
+
+    if (ratingFilters && ratingFilters.length > 0) {
+        ratingFilters.forEach(sel => {
+            sel.addEventListener('change', () => {
+                const values = Array.from(sel.selectedOptions).map(o => o.value);
+                updateSelectedCertifications(values);
+            });
+        });
+        const initial = Array.from(ratingFilters[0].selectedOptions).map(o => o.value);
+        updateSelectedCertifications(initial);
+    }
 
     // Function to handle closing the overlay
     const closeOverlay = () => {

--- a/state.js
+++ b/state.js
@@ -10,7 +10,7 @@ export let currentPopularPage = 1;
 export let currentPopularType = 'movie';
 export let previousStateForBackButton = null;
 export let scrollPositions = { latest: 0, popular: 0 };
-export let selectedCertification = 'All';
+export let selectedCertifications = ['All'];
 
 // Functions to update state
 export function updateCurrentSelectedItemDetails(details) {
@@ -29,7 +29,7 @@ export function updatePopularPage(page) { currentPopularPage = page; }
 export function updatePopularType(type) { currentPopularType = type; }
 export function updatePreviousStateForBackButton(state) { previousStateForBackButton = state; }
 export function updateScrollPosition(type, position) { scrollPositions[type] = position; }
-export function updateSelectedCertification(cert) { selectedCertification = cert; }
+export function updateSelectedCertifications(certs) { selectedCertifications = certs; }
 
 // Active season cards (previously window properties)
 export let itemActiveSeasonCard = null;

--- a/tests/api-url.test.js
+++ b/tests/api-url.test.js
@@ -1,8 +1,8 @@
 import { buildSearchUrl } from '../api.js';
 
 describe('buildSearchUrl', () => {
-  test('includes certification when provided', () => {
-    const url = buildSearchUrl('test', 'movie', 'PG-13');
-    expect(url).toContain('certification=PG-13');
+  test('includes certifications when provided', () => {
+    const url = buildSearchUrl('test', 'movie', ['PG-13', 'R']);
+    expect(url).toContain('certification=PG-13%7CR');
   });
 });


### PR DESCRIPTION
## Summary
- support selecting multiple ratings across tabs
- track selected ratings in state
- propagate selected ratings to search query

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68415c68fd74832397f24839996d51f6