### PR TITLE
Add age rating filtering for watchlist and seen items

### DIFF
--- a/main.js
+++ b/main.js
@@ -3,7 +3,7 @@ import { auth, firebaseAuthFunctions, loadFirebaseIfNeeded } from './firebase.js
 import { initApiRefs, fetchTmdbCategoryContent } from './api.js';
 import { initUiRefs, clearAllDynamicContent, showPositionSavedIndicator, positionPopup, createBackButton, clearItemDetailPanel, clearSearchResultsPanel } from './ui.js'; // Added clearItemDetailPanel, clearSearchResultsPanel
 import { initAuthRefs, handleAuthStateChanged, createAuthFormUI } from './auth.js';
-import { initWatchlistRefs, loadAndDisplayWatchlistsFromFirestore, closeAllOptionMenus, handleCreateWatchlist } from './watchlist.js';
+import { initWatchlistRefs, loadAndDisplayWatchlistsFromFirestore, closeAllOptionMenus, handleCreateWatchlist, displayItemsInSelectedWatchlist } from './watchlist.js';
 import { initSeenListRefs, loadAndDisplaySeenItems } from './seenList.js';
 import { initHandlerRefs, handleSearch, handleItemSelect } from './handlers.js';
 import {
@@ -130,6 +130,9 @@ async function initializeAppState() {
             sel.addEventListener('change', () => {
                 const values = Array.from(sel.selectedOptions).map(o => o.value);
                 updateSelectedCertifications(values);
+                if (sel.id === 'ratingFilterSearch') handleSearch();
+                else if (sel.id === 'ratingFilterWatchlist') displayItemsInSelectedWatchlist();
+                else if (sel.id === 'ratingFilterSeen') loadAndDisplaySeenItems();
             });
         });
         const initial = Array.from(ratingFilters[0].selectedOptions).map(o => o.value);

--- a/ratingUtils.js
+++ b/ratingUtils.js
@@ -1,0 +1,17 @@
+export function extractCertification(detailsObject) {
+    let certification = 'NR';
+    if (!detailsObject) return certification;
+    const itemType = detailsObject.item_type || detailsObject.media_type || 'movie';
+    if (itemType === 'movie' && detailsObject.release_dates?.results) {
+        const usRelease = detailsObject.release_dates.results.find(r => r.iso_3166_1 === 'US');
+        if (usRelease?.release_dates) {
+            const certObj = usRelease.release_dates.find(rd => rd.certification && rd.certification !== '' && ([3,4,5,6].includes(rd.type)))
+                || usRelease.release_dates.find(rd => rd.certification && rd.certification !== '');
+            if (certObj) certification = certObj.certification;
+        }
+    } else if (itemType === 'tv' && detailsObject.content_ratings?.results) {
+        const usRating = detailsObject.content_ratings.results.find(r => r.iso_3166_1 === 'US');
+        if (usRating?.rating && usRating.rating !== '') certification = usRating.rating;
+    }
+    return certification;
+}


### PR DESCRIPTION
## Summary
- add `ratingUtils` helper to extract certification from TMDB details
- store certification when adding items to watchlists and seen list
- filter watchlist and seen items using selected certifications
- trigger filtering when rating filter dropdowns change

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841636341008323972df7abb0304380