### PR TITLE
Add age rating filtering for watchlist and seen items

### DIFF
--- a/main.js
+++ b/main.js
@@ -3,7 +3,7 @@ import { auth, firebaseAuthFunctions, loadFirebaseIfNeeded } from './firebase.js
 import { initApiRefs, fetchTmdbCategoryContent } from './api.js';
 import { initUiRefs, clearAllDynamicContent, showPositionSavedIndicator, positionPopup, createBackButton, clearItemDetailPanel, clearSearchResultsPanel } from './ui.js'; // Added clearItemDetailPanel, clearSearchResultsPanel
 import { initAuthRefs, handleAuthStateChanged, createAuthFormUI } from './auth.js';
-import { initWatchlistRefs, loadAndDisplayWatchlistsFromFirestore, closeAllOptionMenus, handleCreateWatchlist } from './watchlist.js';
+import { initWatchlistRefs, loadAndDisplayWatchlistsFromFirestore, closeAllOptionMenus, handleCreateWatchlist, displayItemsInSelectedWatchlist } from './watchlist.js';
 import { initSeenListRefs, loadAndDisplaySeenItems } from './seenList.js';
 import { initHandlerRefs, handleSearch, handleItemSelect } from './handlers.js';
 import {
@@ -130,6 +130,13 @@ async function initializeAppState() {
             sel.addEventListener('change', () => {
                 const values = Array.from(sel.selectedOptions).map(o => o.value);
                 updateSelectedCertifications(values);
+                if (sel.id === 'ratingFilterSearch') handleSearch();
+                else if (sel.id === 'ratingFilterWatchlist') displayItemsInSelectedWatchlist();
+                else if (sel.id === 'ratingFilterSeen') loadAndDisplaySeenItems();
+                else if (sel.id === 'ratingFilterLatest')
+                    fetchTmdbCategoryContent('latest', currentLatestType, currentLatestCategory, 1);
+                else if (sel.id === 'ratingFilterPopular')
+                    fetchTmdbCategoryContent('popular', currentPopularType, 'popular', 1);
             });
         });
         const initial = Array.from(ratingFilters[0].selectedOptions).map(o => o.value);

--- a/ratingUtils.js
+++ b/ratingUtils.js
@@ -1,0 +1,17 @@
+export function extractCertification(detailsObject) {
+    let certification = 'NR';
+    if (!detailsObject) return certification;
+    const itemType = detailsObject.item_type || detailsObject.media_type || 'movie';
+    if (itemType === 'movie' && detailsObject.release_dates?.results) {
+        const usRelease = detailsObject.release_dates.results.find(r => r.iso_3166_1 === 'US');
+        if (usRelease?.release_dates) {
+            const certObj = usRelease.release_dates.find(rd => rd.certification && rd.certification !== '' && ([3,4,5,6].includes(rd.type)))
+                || usRelease.release_dates.find(rd => rd.certification && rd.certification !== '');
+            if (certObj) certification = certObj.certification;
+        }
+    } else if (itemType === 'tv' && detailsObject.content_ratings?.results) {
+        const usRating = detailsObject.content_ratings.results.find(r => r.iso_3166_1 === 'US');
+        if (usRating?.rating && usRating.rating !== '') certification = usRating.rating;
+    }
+    return certification;
+}

--- a/watchlist.js
+++ b/watchlist.js
@@ -4,8 +4,9 @@ import { showToast, showLoading, showMessage, clearAllDynamicContent, createBack
 import { smallImageBaseUrl, tileThumbnailPlaceholder } from './config.js';
 import {
     currentUserId, currentSelectedWatchlistName, currentSelectedItemDetails,
-    updateCurrentSelectedWatchlistName
+    updateCurrentSelectedWatchlistName, selectedCertifications
 } from './state.js';
+import { extractCertification } from './ratingUtils.js';
 import { handleItemSelect } from './handlers.js'; // For item click
 import { appendSeenCheckmark } from './seenList.js'; // For displaying seen status on watchlist items
 
@@ -180,7 +181,10 @@ export async function displayItemsInSelectedWatchlist() {
         const docSnap = await getDoc(watchlistRef);
 
         if (docSnap.exists()) {
-            const items = docSnap.data().items || [];
+            let items = docSnap.data().items || [];
+            if (!selectedCertifications.includes('All')) {
+                items = items.filter(it => selectedCertifications.includes(it.certification || 'NR'));
+            }
             if (items.length === 0) {
                 watchlistDisplayContainer.innerHTML = `<p class="text-gray-500 italic col-span-full text-center">Watchlist "${currentSelectedWatchlistName}" is empty.</p>`;
             } else {
@@ -203,10 +207,13 @@ export async function addItemToSpecificFirestoreWatchlist(watchlistName, itemDat
     if (!itemData || !itemData.tmdb_id) { showToast("Cannot add item: Invalid item data.", "error"); return false; }
 
     const itemToAdd = {
-        tmdb_id: String(itemData.tmdb_id), title: itemData.title || itemData.name,
-        item_type: itemData.item_type, poster_path: itemData.poster_path || null,
+        tmdb_id: String(itemData.tmdb_id),
+        title: itemData.title || itemData.name,
+        item_type: itemData.item_type,
+        poster_path: itemData.poster_path || null,
         release_year: (itemData.release_date || itemData.first_air_date || '').substring(0, 4),
-        vote_average: itemData.vote_average || null
+        vote_average: itemData.vote_average || null,
+        certification: extractCertification(itemData)
     };
     try {
         const watchlistRef = doc(db, "users", currentUserId, "watchlists", watchlistName);
@@ -439,7 +446,8 @@ export async function populateWatchlistManagePopup(popupElement, itemId, itemDat
             tmdb_id: String(itemData.tmdb_id), title: itemData.title || itemData.name,
             item_type: itemData.item_type, poster_path: itemData.poster_path || null,
             release_year: (itemData.release_date || itemData.first_air_date || '').substring(0,4),
-            vote_average: itemData.vote_average || null
+            vote_average: itemData.vote_average || null,
+            certification: extractCertification(itemData)
         };
 
         await setDoc(newWatchlistRef, { name: name, items: [itemToAddForNewList], createdAt: new Date().toISOString(), uid: currentUserId });


### PR DESCRIPTION
## Summary
- add `ratingUtils` helper to extract certification from TMDB details
- store certification when adding items to watchlists and seen list
- filter watchlist and seen items using selected certifications
- trigger filtering when rating filter dropdowns change
- fix storing certification when creating a new watchlist

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841636341008323972df7abb0304380