### PR TITLE
Add rating filtering for search results

### DIFF
--- a/api.js
+++ b/api.js
@@ -10,7 +10,8 @@ import {
 } from './ui.js';
 // Removed: import { appendSeenCheckmark } from './seenList.js'; // ui.js now handles its own appendSeenCheckmark
 import { smallImageBaseUrl, genericItemPlaceholder, stillImageBaseUrl } from './config.js';
-import { currentSelectedItemDetails, updateCurrentSelectedItemDetails } from './state.js';
+import { currentSelectedItemDetails, updateCurrentSelectedItemDetails, selectedCertifications } from './state.js';
+import { extractCertification } from './ratingUtils.js';
 
 // TMDB API Configuration
 export const apiKey = "e27a888783eeaa67643bd81c5fb4422f"; // Your TMDB API key
@@ -43,7 +44,25 @@ export async function fetchSearchResults(query, itemType, certifications = []) {
         if (!response.ok) throw new Error(`API Error: ${response.statusText}`);
         const data = await response.json();
         if (data.results && data.results.length > 0) {
-            displayResults(data.results, itemType, resultsContainer); // appendSeenCheckmark argument removed
+            let items = data.results;
+            if (!certifications.includes('All')) {
+                items = await Promise.all(items.map(async it => {
+                    try {
+                        const resp = await fetch(`${tmdbBaseUrl}/${itemType}/${it.id}?api_key=${apiKey}&append_to_response=release_dates,content_ratings`);
+                        const details = await resp.json();
+                        const cert = extractCertification({ ...details, item_type: itemType });
+                        return { ...it, certification: cert };
+                    } catch (err) {
+                        return { ...it, certification: 'NR' };
+                    }
+                }));
+                items = items.filter(it => certifications.includes(it.certification));
+            }
+            if (items.length > 0) {
+                displayResults(items, itemType, resultsContainer); // appendSeenCheckmark argument removed
+            } else {
+                showMessage('No results match the selected ratings.', 'info', 'results', resultsContainer);
+            }
         } else {
             showMessage(`No results found for "${query}". Please check spelling or try a different title.`, 'info', 'results', resultsContainer);
         }
@@ -105,7 +124,25 @@ export async function fetchTmdbCategoryContent(mainCategory, type, category, pag
         if (!response.ok) throw new Error(`TMDB API Error: ${response.statusText}`);
         const data = await response.json();
         if (data && data.results && data.results.length > 0) {
-            displayTmdbCategoryItems(data.results, type, displayContainer, mainCategory, category, page, data.total_pages);
+            let items = data.results;
+            if (!selectedCertifications.includes('All')) {
+                items = await Promise.all(items.map(async it => {
+                    try {
+                        const resp = await fetch(`${tmdbBaseUrl}/${type}/${it.id}?api_key=${apiKey}&append_to_response=release_dates,content_ratings`);
+                        const details = await resp.json();
+                        const cert = extractCertification({ ...details, item_type: type });
+                        return { ...it, certification: cert };
+                    } catch (err) {
+                        return { ...it, certification: 'NR' };
+                    }
+                }));
+                items = items.filter(it => selectedCertifications.includes(it.certification));
+            }
+            if (items.length > 0) {
+                displayTmdbCategoryItems(items, type, displayContainer, mainCategory, category, page, data.total_pages);
+            } else {
+                showMessage('No items match the selected ratings.', 'info', mainCategory, displayContainer);
+            }
         } else {
             showMessage('No items found for this category.', 'info', mainCategory, displayContainer);
         }

--- a/main.js
+++ b/main.js
@@ -3,7 +3,7 @@ import { auth, firebaseAuthFunctions, loadFirebaseIfNeeded } from './firebase.js
 import { initApiRefs, fetchTmdbCategoryContent } from './api.js';
 import { initUiRefs, clearAllDynamicContent, showPositionSavedIndicator, positionPopup, createBackButton, clearItemDetailPanel, clearSearchResultsPanel } from './ui.js'; // Added clearItemDetailPanel, clearSearchResultsPanel
 import { initAuthRefs, handleAuthStateChanged, createAuthFormUI } from './auth.js';
-import { initWatchlistRefs, loadAndDisplayWatchlistsFromFirestore, closeAllOptionMenus, handleCreateWatchlist } from './watchlist.js';
+import { initWatchlistRefs, loadAndDisplayWatchlistsFromFirestore, closeAllOptionMenus, handleCreateWatchlist, displayItemsInSelectedWatchlist } from './watchlist.js';
 import { initSeenListRefs, loadAndDisplaySeenItems } from './seenList.js';
 import { initHandlerRefs, handleSearch, handleItemSelect } from './handlers.js';
 import {
@@ -130,6 +130,13 @@ async function initializeAppState() {
             sel.addEventListener('change', () => {
                 const values = Array.from(sel.selectedOptions).map(o => o.value);
                 updateSelectedCertifications(values);
+                if (sel.id === 'ratingFilterSearch') handleSearch();
+                else if (sel.id === 'ratingFilterWatchlist') displayItemsInSelectedWatchlist();
+                else if (sel.id === 'ratingFilterSeen') loadAndDisplaySeenItems();
+                else if (sel.id === 'ratingFilterLatest')
+                    fetchTmdbCategoryContent('latest', currentLatestType, currentLatestCategory, 1);
+                else if (sel.id === 'ratingFilterPopular')
+                    fetchTmdbCategoryContent('popular', currentPopularType, 'popular', 1);
             });
         });
         const initial = Array.from(ratingFilters[0].selectedOptions).map(o => o.value);

--- a/ratingUtils.js
+++ b/ratingUtils.js
@@ -1,0 +1,17 @@
+export function extractCertification(detailsObject) {
+    let certification = 'NR';
+    if (!detailsObject) return certification;
+    const itemType = detailsObject.item_type || detailsObject.media_type || 'movie';
+    if (itemType === 'movie' && detailsObject.release_dates?.results) {
+        const usRelease = detailsObject.release_dates.results.find(r => r.iso_3166_1 === 'US');
+        if (usRelease?.release_dates) {
+            const certObj = usRelease.release_dates.find(rd => rd.certification && rd.certification !== '' && ([3,4,5,6].includes(rd.type)))
+                || usRelease.release_dates.find(rd => rd.certification && rd.certification !== '');
+            if (certObj) certification = certObj.certification;
+        }
+    } else if (itemType === 'tv' && detailsObject.content_ratings?.results) {
+        const usRating = detailsObject.content_ratings.results.find(r => r.iso_3166_1 === 'US');
+        if (usRating?.rating && usRating.rating !== '') certification = usRating.rating;
+    }
+    return certification;
+}

--- a/watchlist.js
+++ b/watchlist.js
@@ -4,8 +4,9 @@ import { showToast, showLoading, showMessage, clearAllDynamicContent, createBack
 import { smallImageBaseUrl, tileThumbnailPlaceholder } from './config.js';
 import {
     currentUserId, currentSelectedWatchlistName, currentSelectedItemDetails,
-    updateCurrentSelectedWatchlistName
+    updateCurrentSelectedWatchlistName, selectedCertifications
 } from './state.js';
+import { extractCertification } from './ratingUtils.js';
 import { handleItemSelect } from './handlers.js'; // For item click
 import { appendSeenCheckmark } from './seenList.js'; // For displaying seen status on watchlist items
 
@@ -180,7 +181,10 @@ export async function displayItemsInSelectedWatchlist() {
         const docSnap = await getDoc(watchlistRef);
 
         if (docSnap.exists()) {
-            const items = docSnap.data().items || [];
+            let items = docSnap.data().items || [];
+            if (!selectedCertifications.includes('All')) {
+                items = items.filter(it => selectedCertifications.includes(it.certification || 'NR'));
+            }
             if (items.length === 0) {
                 watchlistDisplayContainer.innerHTML = `<p class="text-gray-500 italic col-span-full text-center">Watchlist "${currentSelectedWatchlistName}" is empty.</p>`;
             } else {
@@ -203,10 +207,13 @@ export async function addItemToSpecificFirestoreWatchlist(watchlistName, itemDat
     if (!itemData || !itemData.tmdb_id) { showToast("Cannot add item: Invalid item data.", "error"); return false; }
 
     const itemToAdd = {
-        tmdb_id: String(itemData.tmdb_id), title: itemData.title || itemData.name,
-        item_type: itemData.item_type, poster_path: itemData.poster_path || null,
+        tmdb_id: String(itemData.tmdb_id),
+        title: itemData.title || itemData.name,
+        item_type: itemData.item_type,
+        poster_path: itemData.poster_path || null,
         release_year: (itemData.release_date || itemData.first_air_date || '').substring(0, 4),
-        vote_average: itemData.vote_average || null
+        vote_average: itemData.vote_average || null,
+        certification: extractCertification(itemData)
     };
     try {
         const watchlistRef = doc(db, "users", currentUserId, "watchlists", watchlistName);
@@ -439,7 +446,8 @@ export async function populateWatchlistManagePopup(popupElement, itemId, itemDat
             tmdb_id: String(itemData.tmdb_id), title: itemData.title || itemData.name,
             item_type: itemData.item_type, poster_path: itemData.poster_path || null,
             release_year: (itemData.release_date || itemData.first_air_date || '').substring(0,4),
-            vote_average: itemData.vote_average || null
+            vote_average: itemData.vote_average || null,
+            certification: extractCertification(itemData)
         };
 
         await setDoc(newWatchlistRef, { name: name, items: [itemToAddForNewList], createdAt: new Date().toISOString(), uid: currentUserId });


### PR DESCRIPTION
## Summary
- filter search results against selected certifications

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841636341008323972df7abb0304380