### PR TITLE
Add popup-based age rating filters

### DIFF
--- a/api.js
+++ b/api.js
@@ -10,7 +10,8 @@ import {
 } from './ui.js';
 // Removed: import { appendSeenCheckmark } from './seenList.js'; // ui.js now handles its own appendSeenCheckmark
 import { smallImageBaseUrl, genericItemPlaceholder, stillImageBaseUrl } from './config.js';
-import { currentSelectedItemDetails, updateCurrentSelectedItemDetails } from './state.js';
+import { currentSelectedItemDetails, updateCurrentSelectedItemDetails, selectedCertifications } from './state.js';
+import { extractCertification } from './ratingUtils.js';
 
 // TMDB API Configuration
 export const apiKey = "e27a888783eeaa67643bd81c5fb4422f"; // Your TMDB API key
@@ -43,7 +44,25 @@ export async function fetchSearchResults(query, itemType, certifications = []) {
         if (!response.ok) throw new Error(`API Error: ${response.statusText}`);
         const data = await response.json();
         if (data.results && data.results.length > 0) {
-            displayResults(data.results, itemType, resultsContainer); // appendSeenCheckmark argument removed
+            let items = data.results;
+            if (!certifications.includes('All')) {
+                items = await Promise.all(items.map(async it => {
+                    try {
+                        const resp = await fetch(`${tmdbBaseUrl}/${itemType}/${it.id}?api_key=${apiKey}&append_to_response=release_dates,content_ratings`);
+                        const details = await resp.json();
+                        const cert = extractCertification({ ...details, item_type: itemType });
+                        return { ...it, certification: cert };
+                    } catch (err) {
+                        return { ...it, certification: 'NR' };
+                    }
+                }));
+                items = items.filter(it => certifications.includes(it.certification));
+            }
+            if (items.length > 0) {
+                displayResults(items, itemType, resultsContainer); // appendSeenCheckmark argument removed
+            } else {
+                showMessage('No results match the selected ratings.', 'info', 'results', resultsContainer);
+            }
         } else {
             showMessage(`No results found for "${query}". Please check spelling or try a different title.`, 'info', 'results', resultsContainer);
         }
@@ -105,7 +124,25 @@ export async function fetchTmdbCategoryContent(mainCategory, type, category, pag
         if (!response.ok) throw new Error(`TMDB API Error: ${response.statusText}`);
         const data = await response.json();
         if (data && data.results && data.results.length > 0) {
-            displayTmdbCategoryItems(data.results, type, displayContainer, mainCategory, category, page, data.total_pages);
+            let items = data.results;
+            if (!selectedCertifications.includes('All')) {
+                items = await Promise.all(items.map(async it => {
+                    try {
+                        const resp = await fetch(`${tmdbBaseUrl}/${type}/${it.id}?api_key=${apiKey}&append_to_response=release_dates,content_ratings`);
+                        const details = await resp.json();
+                        const cert = extractCertification({ ...details, item_type: type });
+                        return { ...it, certification: cert };
+                    } catch (err) {
+                        return { ...it, certification: 'NR' };
+                    }
+                }));
+                items = items.filter(it => selectedCertifications.includes(it.certification));
+            }
+            if (items.length > 0) {
+                displayTmdbCategoryItems(items, type, displayContainer, mainCategory, category, page, data.total_pages);
+            } else {
+                showMessage('No items match the selected ratings.', 'info', mainCategory, displayContainer);
+            }
         } else {
             showMessage('No items found for this category.', 'info', mainCategory, displayContainer);
         }

--- a/handlers.js
+++ b/handlers.js
@@ -10,7 +10,7 @@ import {
 import {
     previousStateForBackButton, updatePreviousStateForBackButton,
     scrollPositions, updateScrollPosition,
-    updateSelectedCertifications
+    selectedCertifications
 } from './state.js';
 
 // DOM Elements
@@ -21,8 +21,7 @@ let detailOverlay, detailOverlayContent, searchView, latestView, popularView, wa
     overlaySeasonsEpisodesSection, overlayRelatedItemsSection,
     overlayCollectionItemsSection, overlayVidsrcPlayerSection,
     overlayBackButtonContainer,
-    searchInputGlobal,
-    ratingFilterGlobals;
+    searchInputGlobal;
 
 export function initHandlerRefs(elements) {
     detailOverlay = elements.detailOverlay;
@@ -43,7 +42,6 @@ export function initHandlerRefs(elements) {
     overlayVidsrcPlayerSection = elements.overlayVidsrcPlayerSection;
     overlayBackButtonContainer = elements.overlayBackButtonContainer;
     searchInputGlobal = elements.searchInput;
-    ratingFilterGlobals = elements.ratingFilters;
 }
 
 
@@ -114,9 +112,7 @@ export async function handleSearch() {
     if (!searchInputGlobal) { console.error("Search input not initialized in handlers.js"); return; }
     const query = searchInputGlobal.value.trim();
     const itemType = getSelectedSearchType();
-    const ratingSelect = document.getElementById('ratingFilterSearch');
-    const selected = ratingSelect ? Array.from(ratingSelect.selectedOptions).map(o => o.value) : ['All'];
-    updateSelectedCertifications(selected);
+    const selected = selectedCertifications;
     if (!query) {
         showToast("Please enter a title.", "error"); // Ensure showToast is available
         return;

--- a/index.html
+++ b/index.html
@@ -206,10 +206,32 @@
             color: #fde047; /* Lighter yellow for hover */
             background-color: #374151;
         }
-         .watchlist-manage-button.active-popup {
+        .watchlist-manage-button.active-popup {
             background-color: #374151;
             color: #38bdf8;
         }
+
+        /* Rating Filter Styles */
+        .filter-btn {
+            background-color: transparent;
+            color: #9ca3af;
+            padding: 0.5rem;
+            border-radius: 0.375rem;
+            transition: color 0.2s, background-color 0.2s;
+        }
+        .filter-btn:hover { background-color: #374151; color: #e5e7eb; }
+        .rating-filter-popup label { display: flex; align-items: center; gap: 0.5rem; margin-bottom: 0.25rem; }
+        .rating-filter-popup input[type="checkbox"] { accent-color: #38bdf8; }
+        .filter-popup-apply {
+            margin-top: 0.5rem;
+            background-color: #38bdf8;
+            color: white;
+            padding: 0.5rem;
+            border-radius: 0.375rem;
+            width: 100%;
+            text-align: center;
+        }
+        .filter-popup-apply:hover { background-color: #0ea5e9; }
 
         .detail-panel-popup { /* Common class for popups in detail panels */
             position: absolute;
@@ -363,14 +385,24 @@
                 </div>
                 <div class="flex flex-col sm:flex-row gap-4">
                     <input type="text" id="searchInput" placeholder="Enter title (e.g., Inception, Breaking Bad)" class="flex-grow p-3 bg-gray-700 text-white border border-gray-600 rounded-lg focus:ring-2 focus:ring-sky-500 focus:border-sky-500 outline-none">
-                    <select id="ratingFilterSearch" class="rating-filter p-3 bg-gray-700 text-white border border-gray-600 rounded-lg focus:ring-2 focus:ring-sky-500 focus:border-sky-500 outline-none" multiple>
-                        <option value="All">All</option>
-                        <option value="G">G</option>
-                        <option value="PG">PG</option>
-                        <option value="PG-13">PG-13</option>
-                        <option value="R">R</option>
-                        <option value="NC-17">NC-17</option>
-                    </select>
+                    <div class="relative">
+                        <button id="ratingFilterSearchBtn" class="filter-btn" title="Filter by Rating">
+                            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="w-6 h-6">
+                                <path d="M3 4a1 1 0 0 1 1-1h16a1 1 0 0 1 1 1v2.586a1 1 0 0 1-.293.707l-6.414 6.414A2 2 0 0 0 14 15.414V20l-4-2v-2.586a2 2 0 0 0-.293-1.293L3.293 7.293A1 1 0 0 1 3 6.586V4z"/>
+                            </svg>
+                        </button>
+                        <div id="ratingFilterSearchPopup" class="detail-panel-popup rating-filter-popup hidden">
+                            <div class="rating-options">
+                                <label><input type="checkbox" value="All"> All</label>
+                                <label><input type="checkbox" value="G"> G</label>
+                                <label><input type="checkbox" value="PG"> PG</label>
+                                <label><input type="checkbox" value="PG-13"> PG-13</label>
+                                <label><input type="checkbox" value="R"> R</label>
+                                <label><input type="checkbox" value="NC-17"> NC-17</label>
+                            </div>
+                            <button id="ratingFilterSearchApply" class="filter-popup-apply">Apply</button>
+                        </div>
+                    </div>
                     <button id="searchButton" class="bg-sky-500 hover:bg-sky-600 text-white font-semibold py-3 px-6 rounded-lg transition duration-200 shadow-md hover:shadow-lg">Search</button>
                 </div>
             </div>
@@ -394,14 +426,24 @@
                     <div id="watchlistTilesContainer" class="flex flex-wrap gap-3 mb-3 p-1">
                         <p class="text-xs text-gray-400 col-span-full w-full text-center">Sign in to manage watchlists.</p>
                     </div>
-                    <select id="ratingFilterWatchlist" class="rating-filter p-2 bg-gray-700 text-white border border-gray-600 rounded-md focus:ring-2 focus:ring-sky-500 focus:border-sky-500 outline-none" multiple>
-                        <option value="All">All</option>
-                        <option value="G">G</option>
-                        <option value="PG">PG</option>
-                        <option value="PG-13">PG-13</option>
-                        <option value="R">R</option>
-                        <option value="NC-17">NC-17</option>
-                    </select>
+                    <div class="relative inline-block">
+                        <button id="ratingFilterWatchlistBtn" class="filter-btn" title="Filter by Rating">
+                            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="w-5 h-5">
+                                <path d="M3 4a1 1 0 0 1 1-1h16a1 1 0 0 1 1 1v2.586a1 1 0 0 1-.293.707l-6.414 6.414A2 2 0 0 0 14 15.414V20l-4-2v-2.586a2 2 0 0 0-.293-1.293L3.293 7.293A1 1 0 0 1 3 6.586V4z"/>
+                            </svg>
+                        </button>
+                        <div id="ratingFilterWatchlistPopup" class="detail-panel-popup rating-filter-popup hidden">
+                            <div class="rating-options">
+                                <label><input type="checkbox" value="All"> All</label>
+                                <label><input type="checkbox" value="G"> G</label>
+                                <label><input type="checkbox" value="PG"> PG</label>
+                                <label><input type="checkbox" value="PG-13"> PG-13</label>
+                                <label><input type="checkbox" value="R"> R</label>
+                                <label><input type="checkbox" value="NC-17"> NC-17</label>
+                            </div>
+                            <button id="ratingFilterWatchlistApply" class="filter-popup-apply">Apply</button>
+                        </div>
+                    </div>
                 </div>
             </div>
             <div id="watchlistDisplayContainer" class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-4 generic-items-container custom-scrollbar">
@@ -411,14 +453,24 @@
 
         <div id="seenView" class="hidden-view bg-gray-800 p-6 rounded-lg shadow-xl">
             <h2 class="section-title">Seen Items</h2>
-            <select id="ratingFilterSeen" class="rating-filter mb-4 p-2 bg-gray-700 text-white border border-gray-600 rounded-md focus:ring-2 focus:ring-sky-500 focus:border-sky-500 outline-none" multiple>
-                <option value="All">All</option>
-                <option value="G">G</option>
-                <option value="PG">PG</option>
-                <option value="PG-13">PG-13</option>
-                <option value="R">R</option>
-                <option value="NC-17">NC-17</option>
-            </select>
+            <div class="relative inline-block mb-4">
+                <button id="ratingFilterSeenBtn" class="filter-btn" title="Filter by Rating">
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="w-5 h-5">
+                        <path d="M3 4a1 1 0 0 1 1-1h16a1 1 0 0 1 1 1v2.586a1 1 0 0 1-.293.707l-6.414 6.414A2 2 0 0 0 14 15.414V20l-4-2v-2.586a2 2 0 0 0-.293-1.293L3.293 7.293A1 1 0 0 1 3 6.586V4z"/>
+                    </svg>
+                </button>
+                <div id="ratingFilterSeenPopup" class="detail-panel-popup rating-filter-popup hidden">
+                    <div class="rating-options">
+                        <label><input type="checkbox" value="All"> All</label>
+                        <label><input type="checkbox" value="G"> G</label>
+                        <label><input type="checkbox" value="PG"> PG</label>
+                        <label><input type="checkbox" value="PG-13"> PG-13</label>
+                        <label><input type="checkbox" value="R"> R</label>
+                        <label><input type="checkbox" value="NC-17"> NC-17</label>
+                    </div>
+                    <button id="ratingFilterSeenApply" class="filter-popup-apply">Apply</button>
+                </div>
+            </div>
             <div id="seenItemsDisplayContainer" class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-4 generic-items-container custom-scrollbar">
                 <p class="text-gray-500 italic col-span-full text-center">No items marked as seen yet.</p>
             </div>
@@ -431,14 +483,24 @@
                     <button id="latestTvShowsSubTab" class="sub-tab" data-type="tv" data-category="airing_today">Airing Today TV</button>
                 </div>
             </div>
-            <select id="ratingFilterLatest" class="rating-filter mb-4 p-2 bg-gray-700 text-white border border-gray-600 rounded-md focus:ring-2 focus:ring-sky-500 focus:border-sky-500 outline-none" multiple>
-                <option value="All">All</option>
-                <option value="G">G</option>
-                <option value="PG">PG</option>
-                <option value="PG-13">PG-13</option>
-                <option value="R">R</option>
-                <option value="NC-17">NC-17</option>
-            </select>
+            <div class="relative inline-block mb-4">
+                <button id="ratingFilterLatestBtn" class="filter-btn" title="Filter by Rating">
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="w-5 h-5">
+                        <path d="M3 4a1 1 0 0 1 1-1h16a1 1 0 0 1 1 1v2.586a1 1 0 0 1-.293.707l-6.414 6.414A2 2 0 0 0 14 15.414V20l-4-2v-2.586a2 2 0 0 0-.293-1.293L3.293 7.293A1 1 0 0 1 3 6.586V4z"/>
+                    </svg>
+                </button>
+                <div id="ratingFilterLatestPopup" class="detail-panel-popup rating-filter-popup hidden">
+                    <div class="rating-options">
+                        <label><input type="checkbox" value="All"> All</label>
+                        <label><input type="checkbox" value="G"> G</label>
+                        <label><input type="checkbox" value="PG"> PG</label>
+                        <label><input type="checkbox" value="PG-13"> PG-13</label>
+                        <label><input type="checkbox" value="R"> R</label>
+                        <label><input type="checkbox" value="NC-17"> NC-17</label>
+                    </div>
+                    <button id="ratingFilterLatestApply" class="filter-popup-apply">Apply</button>
+                </div>
+            </div>
             <div id="latestContentDisplay" class="space-y-4 custom-scrollbar"></div>
         </div>
 
@@ -449,14 +511,24 @@
                     <button id="popularTvShowsSubTab" class="sub-tab" data-type="tv" data-category="popular">Popular TV Shows</button>
                 </div>
             </div>
-            <select id="ratingFilterPopular" class="rating-filter mb-4 p-2 bg-gray-700 text-white border border-gray-600 rounded-md focus:ring-2 focus:ring-sky-500 focus:border-sky-500 outline-none" multiple>
-                <option value="All">All</option>
-                <option value="G">G</option>
-                <option value="PG">PG</option>
-                <option value="PG-13">PG-13</option>
-                <option value="R">R</option>
-                <option value="NC-17">NC-17</option>
-            </select>
+            <div class="relative inline-block mb-4">
+                <button id="ratingFilterPopularBtn" class="filter-btn" title="Filter by Rating">
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="w-5 h-5">
+                        <path d="M3 4a1 1 0 0 1 1-1h16a1 1 0 0 1 1 1v2.586a1 1 0 0 1-.293.707l-6.414 6.414A2 2 0 0 0 14 15.414V20l-4-2v-2.586a2 2 0 0 0-.293-1.293L3.293 7.293A1 1 0 0 1 3 6.586V4z"/>
+                    </svg>
+                </button>
+                <div id="ratingFilterPopularPopup" class="detail-panel-popup rating-filter-popup hidden">
+                    <div class="rating-options">
+                        <label><input type="checkbox" value="All"> All</label>
+                        <label><input type="checkbox" value="G"> G</label>
+                        <label><input type="checkbox" value="PG"> PG</label>
+                        <label><input type="checkbox" value="PG-13"> PG-13</label>
+                        <label><input type="checkbox" value="R"> R</label>
+                        <label><input type="checkbox" value="NC-17"> NC-17</label>
+                    </div>
+                    <button id="ratingFilterPopularApply" class="filter-popup-apply">Apply</button>
+                </div>
+            </div>
              <div id="popularContentDisplay" class="space-y-4 custom-scrollbar"></div>
         </div>
 

--- a/main.js
+++ b/main.js
@@ -338,4 +338,14 @@ function setupRatingFilters() {
             }
         });
     });
+
+    document.addEventListener('keydown', (e) => {
+        if (e.key === 'Escape') {
+            configs.forEach(cfg => {
+                if (cfg.popup && !cfg.popup.classList.contains('hidden')) {
+                    cfg.popup.classList.add('hidden');
+                }
+            });
+        }
+    });
 }

--- a/ratingUtils.js
+++ b/ratingUtils.js
@@ -1,0 +1,17 @@
+export function extractCertification(detailsObject) {
+    let certification = 'NR';
+    if (!detailsObject) return certification;
+    const itemType = detailsObject.item_type || detailsObject.media_type || 'movie';
+    if (itemType === 'movie' && detailsObject.release_dates?.results) {
+        const usRelease = detailsObject.release_dates.results.find(r => r.iso_3166_1 === 'US');
+        if (usRelease?.release_dates) {
+            const certObj = usRelease.release_dates.find(rd => rd.certification && rd.certification !== '' && ([3,4,5,6].includes(rd.type)))
+                || usRelease.release_dates.find(rd => rd.certification && rd.certification !== '');
+            if (certObj) certification = certObj.certification;
+        }
+    } else if (itemType === 'tv' && detailsObject.content_ratings?.results) {
+        const usRating = detailsObject.content_ratings.results.find(r => r.iso_3166_1 === 'US');
+        if (usRating?.rating && usRating.rating !== '') certification = usRating.rating;
+    }
+    return certification;
+}

--- a/ui.js
+++ b/ui.js
@@ -11,6 +11,7 @@ import {
 import { fetchRecommendations, fetchCollection, fetchEpisodesForSeason } from './api.js';
 import { updateAddToWatchlistButtonState } from './watchlist.js';
 import { updateMarkAsSeenButtonState, appendSeenCheckmark } from './seenList.js';
+import { extractCertification } from './ratingUtils.js';
 import { handleItemSelect } from './handlers.js';
 
 // DOM Elements (initialized in main.js)
@@ -231,9 +232,11 @@ export async function displayItemDetails(imdbId, itemTitleText, detailsObject, i
     const badgesContainer = document.createElement('div');
     badgesContainer.className = 'mb-3 flex flex-wrap items-center';
     if (detailsObject.vote_average) { const ratingBadge = document.createElement('span'); ratingBadge.className = 'detail-badge bg-yellow-500 text-gray-900'; ratingBadge.textContent = `★ ${detailsObject.vote_average.toFixed(1)} (${detailsObject.vote_count} votes)`; badgesContainer.appendChild(ratingBadge); }
-    let certification = 'N/A';
-    if (itemType === 'movie' && detailsObject.release_dates?.results) { const usRelease = detailsObject.release_dates.results.find(r => r.iso_3166_1 === 'US'); if (usRelease?.release_dates) { const certObj = usRelease.release_dates.find(rd => rd.certification && rd.certification !== "" && (rd.type === 3 || rd.type === 4 || rd.type === 5 || rd.type === 6)) || usRelease.release_dates.find(rd => rd.certification && rd.certification !== ""); if (certObj) certification = certObj.certification; } } else if (itemType === 'tv' && detailsObject.content_ratings?.results) { const usRating = detailsObject.content_ratings.results.find(r => r.iso_3166_1 === 'US'); if (usRating?.rating && usRating.rating !== "") certification = usRating.rating; }
-    const ageBadge = document.createElement('span'); ageBadge.className = 'detail-badge bg-sky-500 text-white'; ageBadge.textContent = `Age: ${certification}`; badgesContainer.appendChild(ageBadge);
+    const certification = extractCertification({ ...detailsObject, item_type: itemType });
+    const ageBadge = document.createElement('span');
+    ageBadge.className = 'detail-badge bg-sky-500 text-white';
+    ageBadge.textContent = `Age: ${certification}`;
+    badgesContainer.appendChild(ageBadge);
     if (itemType === 'movie' && detailsObject.runtime) { const runtimeBadge = document.createElement('span'); runtimeBadge.className = 'detail-badge bg-gray-600 text-gray-200'; runtimeBadge.textContent = `Runtime: ${Math.floor(detailsObject.runtime / 60)}h ${detailsObject.runtime % 60}m`; badgesContainer.appendChild(runtimeBadge); } else if (itemType === 'tv' && detailsObject.episode_run_time?.length > 0 && detailsObject.episode_run_time[0] > 0) { const runtimeBadge = document.createElement('span'); runtimeBadge.className = 'detail-badge bg-gray-600 text-gray-200'; runtimeBadge.textContent = `Episode: ~${detailsObject.episode_run_time[0]} min`; badgesContainer.appendChild(runtimeBadge); }
     targetDetailContainerEl.appendChild(badgesContainer);
     if (detailsObject.tagline) { const taglineEl = document.createElement('p'); taglineEl.className = 'text-gray-400 italic mb-2 text-sm'; taglineEl.textContent = detailsObject.tagline; targetDetailContainerEl.appendChild(taglineEl); }

--- a/watchlist.js
+++ b/watchlist.js
@@ -4,8 +4,9 @@ import { showToast, showLoading, showMessage, clearAllDynamicContent, createBack
 import { smallImageBaseUrl, tileThumbnailPlaceholder } from './config.js';
 import {
     currentUserId, currentSelectedWatchlistName, currentSelectedItemDetails,
-    updateCurrentSelectedWatchlistName
+    updateCurrentSelectedWatchlistName, selectedCertifications
 } from './state.js';
+import { extractCertification } from './ratingUtils.js';
 import { handleItemSelect } from './handlers.js'; // For item click
 import { appendSeenCheckmark } from './seenList.js'; // For displaying seen status on watchlist items
 
@@ -180,7 +181,10 @@ export async function displayItemsInSelectedWatchlist() {
         const docSnap = await getDoc(watchlistRef);
 
         if (docSnap.exists()) {
-            const items = docSnap.data().items || [];
+            let items = docSnap.data().items || [];
+            if (!selectedCertifications.includes('All')) {
+                items = items.filter(it => selectedCertifications.includes(it.certification || 'NR'));
+            }
             if (items.length === 0) {
                 watchlistDisplayContainer.innerHTML = `<p class="text-gray-500 italic col-span-full text-center">Watchlist "${currentSelectedWatchlistName}" is empty.</p>`;
             } else {
@@ -203,10 +207,13 @@ export async function addItemToSpecificFirestoreWatchlist(watchlistName, itemDat
     if (!itemData || !itemData.tmdb_id) { showToast("Cannot add item: Invalid item data.", "error"); return false; }
 
     const itemToAdd = {
-        tmdb_id: String(itemData.tmdb_id), title: itemData.title || itemData.name,
-        item_type: itemData.item_type, poster_path: itemData.poster_path || null,
+        tmdb_id: String(itemData.tmdb_id),
+        title: itemData.title || itemData.name,
+        item_type: itemData.item_type,
+        poster_path: itemData.poster_path || null,
         release_year: (itemData.release_date || itemData.first_air_date || '').substring(0, 4),
-        vote_average: itemData.vote_average || null
+        vote_average: itemData.vote_average || null,
+        certification: extractCertification(itemData)
     };
     try {
         const watchlistRef = doc(db, "users", currentUserId, "watchlists", watchlistName);
@@ -439,7 +446,8 @@ export async function populateWatchlistManagePopup(popupElement, itemId, itemDat
             tmdb_id: String(itemData.tmdb_id), title: itemData.title || itemData.name,
             item_type: itemData.item_type, poster_path: itemData.poster_path || null,
             release_year: (itemData.release_date || itemData.first_air_date || '').substring(0,4),
-            vote_average: itemData.vote_average || null
+            vote_average: itemData.vote_average || null,
+            certification: extractCertification(itemData)
         };
 
         await setDoc(newWatchlistRef, { name: name, items: [itemToAddForNewList], createdAt: new Date().toISOString(), uid: currentUserId });


### PR DESCRIPTION
## Summary
- replace rating dropdowns with filter icon popups
- refresh results when applying filters across all tabs

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841636341008323972df7abb0304380