### PR TITLE
Fix PWA paths

### DIFF
--- a/app/manifest.json
+++ b/app/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Jaxs App",
   "short_name": "Jaxs",
-  "start_url": "/app/index.html",
+  "start_url": "/jaxs/app/index.html",
   "display": "standalone",
   "background_color": "#000000",
   "theme_color": "#000000",

--- a/app/sw.js
+++ b/app/sw.js
@@ -3,10 +3,10 @@ self.addEventListener("install", event => {
   event.waitUntil(
     caches.open("jaxs-cache").then(async cache => {
       const files = [
-        "/app/index.html",
-        "/app/appMain.js",
-        "/app/manifest.json",
-        "/app/icon-192.png"
+        "/jaxs/app/index.html",
+        "/jaxs/app/appMain.js",
+        "/jaxs/app/manifest.json",
+        "/jaxs/app/icon-192.png"
       ];
       await Promise.all(
         files.map(async file => {


### PR DESCRIPTION
## Summary
- use absolute path for `start_url`
- update service worker to cache files under `/jaxs/app/`

## Testing
- `npm install` *(fails: no matching version for office-addin-taskpane)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844bd2753b48323b1d6cd0299e6a6c9