### PR TITLE
Add .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,21 @@
+# Dependency directories
+node_modules/
+
+# Build output
+build/
+dist/
+
+# Environment variables
+.env
+.env.*
+
+# Logs
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Misc
+.DS_Store
+
+# Coverage
+coverage/


### PR DESCRIPTION
## Summary
- add standard Node/PWA .gitignore to keep build artifacts and environment files untracked

## Testing
- `npm install` *(fails: No matching version found)*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844d1fda9f4832394722b5254ba35f2