### PR TITLE
Integrate appMain.js into React build

### DIFF
--- a/app/index.jsx
+++ b/app/index.jsx
@@ -2,6 +2,8 @@ import React from 'react';
 import { createRoot } from 'react-dom/client';
 import PageLayout from './PageLayout.jsx';
 
+import './appMain.js';
+
 const container = document.getElementById('root');
 const root = createRoot(container);
 root.render(<PageLayout />);

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -8,6 +8,7 @@ export default {
   output: {
     filename: 'bundle.js',
     path: path.resolve(__dirname, 'dist'),
+    module: true,
   },
   module: {
     rules: [
@@ -30,5 +31,14 @@ export default {
     static: {
       directory: path.join(__dirname, 'app'),
     },
+  },
+  experiments: {
+    outputModule: true,
+  },
+  externalsType: 'module',
+  externals: {
+    'https://www.gstatic.com/firebasejs/10.12.2/firebase-app.js': 'module https://www.gstatic.com/firebasejs/10.12.2/firebase-app.js',
+    'https://www.gstatic.com/firebasejs/10.12.2/firebase-auth.js': 'module https://www.gstatic.com/firebasejs/10.12.2/firebase-auth.js',
+    'https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore.js': 'module https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore.js'
   },
 };


### PR DESCRIPTION
## Summary
- load `appMain.js` from the React entry point
- adjust webpack to output ESM and treat Firebase CDN files as module externals

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6844fdc1c51883239dda5c5998789f9d