### PR TITLE
Fix DOMContentLoaded closure and login input

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -915,7 +915,7 @@
                 </div>
                 <div>
                     <label for="password-input" style="display:block; margin-bottom: 0.5rem; font-weight: 500;">Password</label>
-                    <input type="password" id="password-input" name="password" required>
+                    <input type="password" id="password-input" name="password" required autocomplete="current-password">
                 </div>
                 <button type="submit" id="sign-in-submit-button" class="apple-like-button" style="margin-top:1.5rem; background-color: var(--black); color: var(--white); border: 1px solid var(--black); border-radius: 10px; font-weight:500;">Sign In</button>
             </form>

--- a/app/main.js
+++ b/app/main.js
@@ -824,4 +824,5 @@ document.addEventListener('DOMContentLoaded', async () => {
             toggleSeenStatus(details, itemType);
         }
     });
-;
+
+});


### PR DESCRIPTION
## Summary
- fix missing closing brace for DOMContentLoaded handler in `app/main.js`
- add `autocomplete` attribute to sign‑in form

## Testing
- `npm install` *(fails: No matching version found for office-addin-taskpane@^0.8.6)*

------
https://chatgpt.com/codex/tasks/task_e_6845c5fc3a0c8323a57b016d864bef40