### PR TITLE
Fix duplicate functions in watchlist.js

### DIFF
--- a/watchlist.js
+++ b/watchlist.js
@@ -97,7 +97,50 @@ export function displayWatchlistSelection() {
                 }
                 clearAllDynamicContent('watchlist');
             });
-            watchlistTilesContainer.appendChild(tile);
+  watchlistTilesContainer.appendChild(tile);
+       });
+   }
+}
+
+// --- Use cache for item checks ---
+export function isItemInSpecificFirestoreWatchlist(watchlistName, itemId) {
+    const watchlist = getCachedWatchlists().find(wl => wl.id === watchlistName);
+    if (!watchlist) return false;
+    return (watchlist.items || []).some(item => String(item.tmdb_id) === String(itemId));
+}
+
+export function isItemInAnyFirestoreWatchlist(itemId) {
+    return getCachedWatchlists().some(wl =>
+        (wl.items || []).some(item => String(item.tmdb_id) === String(itemId))
+    );
+}
+
+// --- Use cache for displaying items ---
+export function displayItemsInSelectedWatchlist() {
+    if (!watchlistDisplayContainer) return;
+    watchlistDisplayContainer.innerHTML = '';
+    if (!currentUserId) {
+        watchlistDisplayContainer.innerHTML = '<p class="text-gray-500 italic col-span-full text-center">Please sign in to view watchlist items.</p>';
+        return;
+    }
+    if (!currentSelectedWatchlistName) {
+        watchlistDisplayContainer.innerHTML = '<p class="text-gray-500 italic col-span-full text-center">Select a watchlist or create one.</p>';
+        return;
+    }
+    const watchlist = getCachedWatchlists().find(wl => wl.id === currentSelectedWatchlistName);
+    if (!watchlist) {
+        watchlistDisplayContainer.innerHTML = `<p class="text-gray-500 italic col-span-full text-center">Watchlist "${currentSelectedWatchlistName}" not found.</p>`;
+        return;
+    }
+    let items = watchlist.items || [];
+    if (!selectedCertifications.includes('All')) {
+        items = items.filter(it => selectedCertifications.includes(it.certification || 'NR'));
+    }
+    if (items.length === 0) {
+        watchlistDisplayContainer.innerHTML = `<p class="text-gray-500 italic col-span-full text-center">Watchlist "${currentSelectedWatchlistName}" is empty.</p>`;
+    } else {
+        items.forEach(item => {
+            watchlistDisplayContainer.appendChild(createWatchlistItemCard(item));
         });
     }
 }
@@ -191,207 +234,6 @@ export async function handleDeleteWatchlist(watchlistName) {
     } catch (error) { console.error("Error deleting watchlist: ", error); showToast("Failed to delete watchlist. Check console.", "error"); }
 }
 
-export function displayWatchlistSelection() {
-    if (!watchlistTilesContainer) return;
-    watchlistTilesContainer.innerHTML = '';
-    if (!currentUserId) {
-        watchlistTilesContainer.innerHTML = '<p class="text-xs text-gray-400 col-span-full w-full text-center">Sign in to manage watchlists.</p>';
-        return;
-    }
-
-    const firestoreWatchlists = getCachedWatchlists();
-
-    if (firestoreWatchlists.length === 0) {
-        watchlistTilesContainer.innerHTML = '<p class="text-xs text-gray-400 col-span-full w-full text-center">No watchlists created yet.</p>';
-    } else {
-        firestoreWatchlists.forEach(watchlistDoc => {
-            const name = watchlistDoc.id;
-            const tile = document.createElement('div');
-            tile.className = 'watchlist-tile';
-            tile.dataset.watchlistName = name;
-
-            const itemsInWatchlist = watchlistDoc.items || [];
-            let thumbnailUrl = tileThumbnailPlaceholder;
-            if (itemsInWatchlist.length > 0 && itemsInWatchlist[0].poster_path) {
-                thumbnailUrl = `${smallImageBaseUrl}${itemsInWatchlist[0].poster_path}`;
-            }
-
-            const tileNameSpan = document.createElement('span');
-            tileNameSpan.className = 'watchlist-tile-name';
-            tileNameSpan.title = name;
-            tileNameSpan.textContent = name;
-
-            const optionsButton = document.createElement('button');
-            optionsButton.className = 'watchlist-tile-options-btn';
-            optionsButton.innerHTML = '&#x22EE;';
-            optionsButton.title = `Options for ${name}`;
-
-            optionsButton.addEventListener('click', (e) => {
-                e.stopPropagation();
-                toggleOptionsMenu(tile, name);
-            });
-
-            tile.innerHTML = ` <img src="${thumbnailUrl}" alt="${name} thumbnail" onerror="this.src='${tileThumbnailPlaceholder}'; this.onerror=null;"> `;
-            tile.appendChild(tileNameSpan);
-            tile.appendChild(optionsButton);
-
-            if (name === currentSelectedWatchlistName) {
-                tile.classList.add('selected-watchlist-tile');
-            }
-
-            tile.addEventListener('click', async (e) => {
-                if (e.target.closest('.watchlist-tile-options-btn') || e.target.closest('.options-menu')) return;
-                closeAllOptionMenus();
-                if (watchlistTilesContainer) {
-                    watchlistTilesContainer.querySelectorAll('.watchlist-tile').forEach(t => t.classList.remove('selected-watchlist-tile'));
-                }
-                tile.classList.add('selected-watchlist-tile');
-                updateCurrentSelectedWatchlistName(name);
-                if (currentUserId)
-                    await displayItemsInSelectedWatchlist();
-                if (currentSelectedItemDetails) {
-                    // Optionally update detail panel if needed
-                }
-                clearAllDynamicContent('watchlist');
-            });
-            watchlistTilesContainer.appendChild(tile);
-        });
-    }
-}
-
-// --- Use cache for item checks ---
-export function isItemInSpecificFirestoreWatchlist(watchlistName, itemId) {
-    const watchlist = getCachedWatchlists().find(wl => wl.id === watchlistName);
-    if (!watchlist) return false;
-    return (watchlist.items || []).some(item => String(item.tmdb_id) === String(itemId));
-}
-
-export function isItemInAnyFirestoreWatchlist(itemId) {
-    return getCachedWatchlists().some(wl =>
-        (wl.items || []).some(item => String(item.tmdb_id) === String(itemId))
-    );
-}
-
-// --- Use cache for displaying items ---
-export function displayItemsInSelectedWatchlist() {
-    if (!watchlistDisplayContainer) return;
-    watchlistDisplayContainer.innerHTML = '';
-    if (!currentUserId) {
-        watchlistDisplayContainer.innerHTML = '<p class="text-gray-500 italic col-span-full text-center">Please sign in to view watchlist items.</p>';
-        return;
-    }
-    if (!currentSelectedWatchlistName) {
-        watchlistDisplayContainer.innerHTML = '<p class="text-gray-500 italic col-span-full text-center">Select a watchlist or create one.</p>';
-        return;
-    }
-    const watchlist = getCachedWatchlists().find(wl => wl.id === currentSelectedWatchlistName);
-    if (!watchlist) {
-        watchlistDisplayContainer.innerHTML = `<p class="text-gray-500 italic col-span-full text-center">Watchlist "${currentSelectedWatchlistName}" not found.</p>`;
-        return;
-    }
-    let items = watchlist.items || [];
-    if (!selectedCertifications.includes('All')) {
-        items = items.filter(it => selectedCertifications.includes(it.certification || 'NR'));
-    }
-    if (items.length === 0) {
-        watchlistDisplayContainer.innerHTML = `<p class="text-gray-500 italic col-span-full text-center">Watchlist "${currentSelectedWatchlistName}" is empty.</p>`;
-    } else {
-        items.forEach(item => {
-            watchlistDisplayContainer.appendChild(createWatchlistItemCard(item));
-        });
-    }
-}
-
-export async function addItemToSpecificFirestoreWatchlist(watchlistName, itemData) {
-    if (!currentUserId) { showToast("Please sign in to add items.", "error"); return false; }
-    if (!watchlistName) { showToast("Watchlist name not specified.", "error"); return false; }
-    if (!itemData || !itemData.tmdb_id) { showToast("Cannot add item: Invalid item data.", "error"); return false; }
-
-    const itemToAdd = {
-        tmdb_id: String(itemData.tmdb_id),
-        title: itemData.title || itemData.name,
-        item_type: itemData.item_type,
-        poster_path: itemData.poster_path || null,
-        release_year: (itemData.release_date || itemData.first_air_date || '').substring(0, 4),
-        vote_average: itemData.vote_average || null,
-        certification: extractCertification(itemData)
-    };
-    try {
-        const watchlistRef = doc(db, "users", currentUserId, "watchlists", watchlistName);
-        await updateDoc(watchlistRef, { items: arrayUnion(itemToAdd) });
-        await window.loadUserFirestoreWatchlists(); // Refresh cache after mutation
-        showToast(`"${itemToAdd.title}" added to ${watchlistName}.`, "success");
-        if (currentSelectedWatchlistName === watchlistName && watchlistView && !watchlistView.classList.contains('hidden-view')) {
-            await displayItemsInSelectedWatchlist();
-        }
-        await loadAndDisplayWatchlistsFromFirestore();
-        return true;
-    } catch (error) {
-        console.error(`Error adding item to ${watchlistName}: `, error);
-        showToast(`Failed to add item to ${watchlistName}.`, "error");
-        return false;
-    }
-}
-
-export async function removeItemFromSpecificFirestoreWatchlist(watchlistName, itemIdToRemove) {
-    if (!currentUserId) { showToast("Please sign in to remove items.", "error"); return false; }
-    if (!watchlistName) { showToast("Watchlist name not specified.", "error"); return false; }
-    try {
-        const watchlistRef = doc(db, "users", currentUserId, "watchlists", watchlistName);
-        const docSnap = await getDoc(watchlistRef);
-        let itemTitleForToast = "Item";
-
-        if (docSnap.exists()) {
-            const currentItems = docSnap.data().items || [];
-            const itemToRemoveObject = currentItems.find(item => String(item.tmdb_id) === String(itemIdToRemove));
-            if (itemToRemoveObject) {
-                itemTitleForToast = itemToRemoveObject.title;
-                await updateDoc(watchlistRef, { items: arrayRemove(itemToRemoveObject) });
-                await window.loadUserFirestoreWatchlists(); // Refresh cache after mutation
-                showToast(`"${itemTitleForToast}" removed from ${watchlistName}.`, "info");
-                if (currentSelectedWatchlistName === watchlistName && watchlistView && !watchlistView.classList.contains('hidden-view')) {
-                    await displayItemsInSelectedWatchlist();
-                }
-                await loadAndDisplayWatchlistsFromFirestore();
-                return true;
-            } else {
-                console.log("Item not found in watchlist for removal:", itemIdToRemove, "from", watchlistName);
-                return false;
-            }
-        }
-        return false;
-    } catch (error) {
-        console.error(`Error removing item from ${watchlistName}: `, error);
-        showToast(`Failed to remove item from ${watchlistName}.`, "error");
-        return false;
-    }
-}
-
-export async function handleDeleteWatchlist(watchlistName) {
-    if (!currentUserId) { showToast("You must be signed in to delete a watchlist.", "error"); return; }
-    if (!watchlistName) { console.error("[handleDeleteWatchlist] Called with no name."); return; }
-
-    try {
-        await deleteDoc(doc(db, "users", currentUserId, "watchlists", watchlistName));
-        await window.loadUserFirestoreWatchlists(); // Refresh cache after mutation
-
-        if (currentSelectedWatchlistName === watchlistName) {
-            updateCurrentSelectedWatchlistName(null);
-            localStorage.removeItem(`mediaFinderLastSelectedWatchlist_${currentUserId}`);
-        }
-
-        await loadAndDisplayWatchlistsFromFirestore();
-        showToast(`Watchlist "${watchlistName}" deleted.`, "info");
-
-        if (currentSelectedItemDetails) {
-            const activeBtnContainerId = determineActiveWatchlistButtonContainerId();
-            updateAddToWatchlistButtonState(currentSelectedItemDetails.tmdb_id, currentSelectedItemDetails, activeBtnContainerId);
-        }
-    } catch (error) {
-        console.error("Error deleting watchlist: ", error);
-        showToast("Failed to delete watchlist. Check console.", "error");
-    }
-}
 
 export async function handleCreateWatchlist() {
     if (!currentUserId) { showToast("You must be signed in to create a watchlist.", "error"); return; }


### PR DESCRIPTION
## Summary
- remove duplicate implementations for watchlist actions
- reintroduce unique helper functions for checking and displaying watchlist contents

## Testing
- `node --check watchlist.js`
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846940f7b308323a861167e3bf525fc