### PR TITLE
Add webpack config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+dist/
+bundle.js

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "start": "webpack serve --mode development",
-    "build": "webpack --mode production",
+    "start": "webpack serve --config webpack.config.js --mode development",
+    "build": "webpack --config webpack.config.js --mode production",
     "test": "jest"
   },
   "keywords": [],

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,13 @@
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+export default {
+  entry: './main.js',
+  output: {
+    filename: 'bundle.js',
+    path: path.resolve(__dirname, 'dist'),
+  },
+};


### PR DESCRIPTION
## Summary
- add webpack config for bundling `main.js`
- update npm scripts to use the config
- ignore build artifacts

## Testing
- `NODE_OPTIONS=--experimental-vm-modules npm test` *(fails: Cannot find module 'https://www.gstatic.com/firebasejs/10.12.2/firebase-app.js' from 'firebase.js')*

------
https://chatgpt.com/codex/tasks/task_e_6847216d3cfc83239969da37782a0d99