### PR TITLE
Update test script env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Run the Jest test suite:
 npm test
 ```
 
-Some environments may require `NODE_OPTIONS=--experimental-vm-modules` for ESM support.
+The test script sets `NODE_OPTIONS=--experimental-vm-modules` to enable ESM support required by Jest.
 
 ## Build
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "webpack serve --config webpack.config.js --mode development",
     "build": "webpack --config webpack.config.js --mode production",
-    "test": "jest"
+    "test": "NODE_OPTIONS=--experimental-vm-modules jest"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Summary
- set NODE_OPTIONS=--experimental-vm-modules in `npm test` script
- mention this requirement in README

## Testing
- `npm test` *(fails: jest not found)*
- `npm install --no-progress` *(fails: ENOTEMPTY directory not empty)*

------
https://chatgpt.com/codex/tasks/task_e_6847244b15ac8323af95291c3c21ade9