### PR TITLE
Fix watchlist cache exposure

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -10,6 +10,7 @@ let cachedNewReleaseMovies = [];
 let cachedSearchResults = []; // Moved from dataset to global for easier access
 let localUserSeenItemsCache = []; // Cache for seen items for the current user
 let firestoreWatchlistsCache = []; // Global cache for Firestore watchlists
+window.firestoreWatchlistsCache = firestoreWatchlistsCache;
 
 // Global variable for current filter state
 let currentAgeRatingFilter = []; // Default to no filter (empty array means 'All Ratings')
@@ -969,7 +970,6 @@ async function renderMoviesInSelectedFolder(folderName) {
         }
     }
 });
-window.firestoreWatchlistsCache = firestoreWatchlistsCache;
 window.loadUserFirestoreWatchlists = loadUserFirestoreWatchlists;
 window.renderLibraryFolderCards = renderLibraryFolderCards;
 


### PR DESCRIPTION
## Summary
- expose `firestoreWatchlistsCache` on `window` immediately after it's declared
- remove redundant assignment at the bottom of the app script

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68473d8768c08323977b7afe065808ac