### PR TITLE
Add Firestore watchlist loader

### DIFF
--- a/tests/loadUserFirestoreWatchlists.test.js
+++ b/tests/loadUserFirestoreWatchlists.test.js
@@ -1,0 +1,21 @@
+import { jest } from '@jest/globals';
+
+jest.unstable_mockModule('https://www.gstatic.com/firebasejs/10.12.2/firebase-app.js', () => ({}), { virtual: true });
+jest.unstable_mockModule('https://www.gstatic.com/firebasejs/10.12.2/firebase-auth.js', () => ({}), { virtual: true });
+jest.unstable_mockModule('https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore.js', () => ({}), { virtual: true });
+
+jest.unstable_mockModule('../firebase.js', () => ({
+  db: {},
+  auth: {},
+  firebaseAuthFunctions: {},
+  firebaseFirestoreFunctions: {},
+  loadFirebaseIfNeeded: async () => {}
+}));
+
+await import('../main.js');
+
+describe('main.js global functions', () => {
+  test('loadUserFirestoreWatchlists is defined on window', () => {
+    expect(typeof window.loadUserFirestoreWatchlists).toBe('function');
+  });
+});


### PR DESCRIPTION
## Summary
- implement `loadUserFirestoreWatchlists` in `main.js`
- expose new global so watchlist module works
- test that the global loader exists in main

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68474d624cd083239b866eb1290f0f88