### PR TITLE
Switch Firebase to npm import

### DIFF
--- a/firebase.js
+++ b/firebase.js
@@ -1,4 +1,31 @@
 // js/firebase.js
+import {
+    initializeApp,
+    getApps,
+    getApp,
+} from 'firebase/app';
+import {
+    getAuth,
+    createUserWithEmailAndPassword,
+    signInWithEmailAndPassword,
+    signOut,
+    onAuthStateChanged,
+} from 'firebase/auth';
+import {
+    getFirestore,
+    collection,
+    getDocs,
+    doc,
+    setDoc,
+    deleteDoc,
+    updateDoc,
+    arrayUnion,
+    arrayRemove,
+    getDoc,
+    query,
+    where,
+} from 'firebase/firestore';
+
 const firebaseConfig = {
     apiKey: "AIzaSyAsLscv3km_0ywQFQb-1D3JhoN3pBS_ia8",
     authDomain: "watchlist-app-c5ecb.firebaseapp.com",
@@ -15,39 +42,35 @@ let firebaseAuthFunctions = {};
 let firebaseFirestoreFunctions = {};
 
 if (typeof process === 'undefined') {
-    const appMod = await import('https://www.gstatic.com/firebasejs/10.12.2/firebase-app.js');
-    const authMod = await import('https://www.gstatic.com/firebasejs/10.12.2/firebase-auth.js');
-    const fsMod = await import('https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore.js');
-
     let app;
-    if (!appMod.getApps().length) {
-        app = appMod.initializeApp(firebaseConfig);
+    if (!getApps().length) {
+        app = initializeApp(firebaseConfig);
     } else {
-        app = appMod.getApp();
+        app = getApp();
     }
 
-    db = fsMod.getFirestore(app);
-    auth = authMod.getAuth(app);
+    db = getFirestore(app);
+    auth = getAuth(app);
 
     firebaseAuthFunctions = {
-        createUserWithEmailAndPassword: authMod.createUserWithEmailAndPassword,
-        signInWithEmailAndPassword: authMod.signInWithEmailAndPassword,
-        signOut: authMod.signOut,
-        onAuthStateChanged: authMod.onAuthStateChanged
+        createUserWithEmailAndPassword,
+        signInWithEmailAndPassword,
+        signOut,
+        onAuthStateChanged
     };
 
     firebaseFirestoreFunctions = {
-        collection: fsMod.collection,
-        getDocs: fsMod.getDocs,
-        doc: fsMod.doc,
-        setDoc: fsMod.setDoc,
-        deleteDoc: fsMod.deleteDoc,
-        updateDoc: fsMod.updateDoc,
-        arrayUnion: fsMod.arrayUnion,
-        arrayRemove: fsMod.arrayRemove,
-        getDoc: fsMod.getDoc,
-        query: fsMod.query,
-        where: fsMod.where
+        collection,
+        getDocs,
+        doc,
+        setDoc,
+        deleteDoc,
+        updateDoc,
+        arrayUnion,
+        arrayRemove,
+        getDoc,
+        query,
+        where
     };
 } else {
     firebaseAuthFunctions = {

--- a/package.json
+++ b/package.json
@@ -21,5 +21,8 @@
   },
   "jest": {
     "testEnvironment": "jsdom"
+  },
+  "dependencies": {
+    "firebase": "^10.14.1"
   }
 }

--- a/tests/api-url.test.js
+++ b/tests/api-url.test.js
@@ -1,7 +1,7 @@
 import { jest } from '@jest/globals';
-jest.unstable_mockModule('https://www.gstatic.com/firebasejs/10.12.2/firebase-app.js', () => ({}), { virtual: true });
-jest.unstable_mockModule('https://www.gstatic.com/firebasejs/10.12.2/firebase-auth.js', () => ({}), { virtual: true });
-jest.unstable_mockModule('https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore.js', () => ({}), { virtual: true });
+jest.unstable_mockModule('firebase/app', () => ({}), { virtual: true });
+jest.unstable_mockModule('firebase/auth', () => ({}), { virtual: true });
+jest.unstable_mockModule('firebase/firestore', () => ({}), { virtual: true });
 jest.unstable_mockModule('../firebase.js', () => ({
   db: {},
   auth: {},

--- a/tests/loadUserFirestoreWatchlists.test.js
+++ b/tests/loadUserFirestoreWatchlists.test.js
@@ -1,8 +1,8 @@
 import { jest } from '@jest/globals';
 
-jest.unstable_mockModule('https://www.gstatic.com/firebasejs/10.12.2/firebase-app.js', () => ({}), { virtual: true });
-jest.unstable_mockModule('https://www.gstatic.com/firebasejs/10.12.2/firebase-auth.js', () => ({}), { virtual: true });
-jest.unstable_mockModule('https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore.js', () => ({}), { virtual: true });
+jest.unstable_mockModule('firebase/app', () => ({}), { virtual: true });
+jest.unstable_mockModule('firebase/auth', () => ({}), { virtual: true });
+jest.unstable_mockModule('firebase/firestore', () => ({}), { virtual: true });
 
 jest.unstable_mockModule('../firebase.js', () => ({
   db: {},


### PR DESCRIPTION
## Summary
- install Firebase locally
- load Firebase modules from package instead of CDN
- update Firebase mocks in tests

## Testing
- `npm test` *(fails: Cannot find module '/workspace/jaxs/node_modules/jest-util/build/index.js')*
- `npm run build` *(fails: Cannot find module './lib/argument.js')*

------
https://chatgpt.com/codex/tasks/task_e_6847de2542e08323a9f761007cdf368b