### PR TITLE
Add html-webpack-plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,9 @@ Create a production build with webpack:
 npm run build
 ```
 
+The build uses `html-webpack-plugin` to process `index.html` and output it to
+`dist/` with the compiled `bundle.js` automatically injected.
+
 The bundled files will be placed in the `dist/` directory. Serve them with any
 static file server, for example:
 

--- a/index.html
+++ b/index.html
@@ -720,6 +720,5 @@
         <div id="messageArea"></div>
     </div>
 
-    <script type="module" src="./main.js"></script>
 </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "license": "ISC",
   "type": "module",
   "devDependencies": {
+    "html-webpack-plugin": "^5.6.3",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^30.0.0-beta.3",
     "webpack": "^5.90.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,6 @@
 import path from 'path';
 import { fileURLToPath } from 'url';
+import HtmlWebpackPlugin from 'html-webpack-plugin';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -10,4 +11,9 @@ export default {
     filename: 'bundle.js',
     path: path.resolve(__dirname, 'dist'),
   },
+  plugins: [
+    new HtmlWebpackPlugin({
+      template: './index.html',
+    }),
+  ],
 };


### PR DESCRIPTION
## Summary
- add html-webpack-plugin dependency
- configure webpack to use html-webpack-plugin
- remove old script tag in index.html so the plugin can inject bundle.js
- document build behavior in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6847e08509a48323bfba9ff62c8b4075